### PR TITLE
Add latest version of CodePush plugin support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
       "react-native-lluploader@0.0.3",
       "react-native-llimageview@0.0.5",
       "react-native-electrode-bridge@1.5.5",
-      "react-native-location@0.27.0"      
+      "react-native-location@0.27.0"
     ],
     "targetJsDependencies": [
     ]
@@ -33,7 +33,8 @@
       "react-native-electrode-bridge@1.5.9",
       "react-native-maps@0.16.4",
       "react-native-vector-icons@4.4.0",
-      "react-native-linear-gradient@2.3.0"
+      "react-native-linear-gradient@2.3.0",
+      "react-native-code-push@5.1.3-beta"
     ],
     "targetJsDependencies": [
     ]
@@ -45,7 +46,8 @@
       "react-native-electrode-bridge@1.5.9",
       "react-native-maps@0.16.4",
       "react-native-vector-icons@4.4.0",
-      "react-native-linear-gradient@2.3.0"
+      "react-native-linear-gradient@2.3.0",
+      "react-native-code-push@5.1.3-beta"
     ],
     "targetJsDependencies": [
     ]

--- a/plugins/ern_v0.5.0+/react-native-code-push_v5.1.1+/CodePushPlugin.java
+++ b/plugins/ern_v0.5.0+/react-native-code-push_v5.1.1+/CodePushPlugin.java
@@ -1,0 +1,55 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.microsoft.codepush.react.CodePush;
+
+public class CodePushPlugin {
+
+    public ReactPackage hook(@NonNull Application application ,
+                     @NonNull ReactInstanceManagerBuilder reactInstanceManagerBuilder,
+                     @NonNull Config config) {
+        CodePush codePush = null;
+        if (null != config.serverUrl) {
+            codePush = new CodePush(
+                          config.deploymentKey,
+                          application,
+                          config.isDebugModeEnabled,
+                          config.serverUrl);
+        } else {
+            codePush = new CodePush(
+                          config.deploymentKey,
+                          application,
+                          config.isDebugModeEnabled);
+        }
+
+        reactInstanceManagerBuilder
+                .setJSBundleFile(CodePush.getJSBundleFile())
+                .addPackage(codePush);
+
+        return codePush;
+    }
+
+    public static class Config {
+        private final String deploymentKey;
+        private String serverUrl;
+        private boolean isDebugModeEnabled;
+
+        public Config(@NonNull String deploymentKey) {
+            this.deploymentKey = deploymentKey;
+        }
+
+        public Config serverUrl(String serverUrl) {
+            this.serverUrl = serverUrl;
+            return this;
+        }
+
+        public Config enableDebugMode(boolean isEnabled) {
+            this.isDebugModeEnabled = isEnabled;
+            return this;
+        }
+    }
+}

--- a/plugins/ern_v0.5.0+/react-native-code-push_v5.1.1+/ElectrodeCodePushConfig.h
+++ b/plugins/ern_v0.5.0+/react-native-code-push_v5.1.1+/ElectrodeCodePushConfig.h
@@ -1,0 +1,24 @@
+//
+//  ElectrodeCodePushConfig.h
+//  ElectrodeContainer
+//
+//  Created by Claire Weijie Li on 6/27/17.
+//  Copyright © 2017 Walmart. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "ElectrodeReactNative.h"
+NS_ASSUME_NONNULL_BEGIN
+@interface ElectrodeCodePushConfig : NSObject<ElectrodePluginConfig>
+
+@property(nonatomic, copy, readonly) NSString *deploymentKey;
+@property(nonatomic, copy, readonly, nullable) NSString *serverURL;
+
+- (instancetype) initWithDeploymentKey:(NSString *)deploymentKey
+                             serverURL: (NSURL * _Nullable)severURL
+                       containerConfig: (ElectrodeContainerConfig *)containerConfig;
+- (NSURL *) codePushBundleURL;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/plugins/ern_v0.5.0+/react-native-code-push_v5.1.1+/ElectrodeCodePushConfig.m
+++ b/plugins/ern_v0.5.0+/react-native-code-push_v5.1.1+/ElectrodeCodePushConfig.m
@@ -1,0 +1,67 @@
+//
+//  ElectrodeCodePushConfig.m
+//  ElectrodeContainer
+//
+//  Created by Claire Weijie Li on 6/27/17.
+//  Copyright © 2017 Walmart. All rights reserved.
+//
+
+#import "ElectrodeCodePushConfig.h"
+#import <CodePush/CodePush.h>
+
+#if __has_include(<React/RCTBridgeDelegate.h>)
+#import <React/RCTBridgeDelegate.h>
+#elif __has_include("RCTBridgeDelegate.h")
+#import "RCTBridgeDelegate.h"
+#else
+#import "React/RCTBridgeDelegate.h"   // Required when used as a Pod in a Swift project
+#endif
+
+#import "ElectrodeBridgeDelegate.h"
+@interface ElectrodeCodePushConfig()
+
+@property(nonatomic, copy) NSString *deploymentKey;
+@property(nonatomic, copy, nullable) NSString *serverURL;
+@property(nonatomic, weak, nullable) ElectrodeContainerConfig *containerConfig;
+
+@end
+@implementation ElectrodeCodePushConfig
+
+- (instancetype) initWithDeploymentKey:(NSString *)deploymentKey
+                             serverURL: (NSString * _Nullable)serverURL
+                       containerConfig: (ElectrodeContainerConfig *)containerConfig
+{
+    if (self = [super init]) {
+        _deploymentKey = deploymentKey;
+        _serverURL = serverURL;
+        _containerConfig = containerConfig;
+    }
+    
+    return self;
+}
+
+- (void)setupConfigWithDelegate: (id<RCTBridgeDelegate>) delegate {
+    [CodePush initialize];
+    [CodePush setDeploymentKey:self.deploymentKey];
+    if (self.serverURL) {
+      [CodePushConfig current].serverURL = self.serverURL;
+    }
+    if (!self.containerConfig.debugEnabled) {
+        if ([delegate isKindOfClass:[ElectrodeBridgeDelegate class]]) {
+            ElectrodeBridgeDelegate *bridgeDelegate = (ElectrodeBridgeDelegate *)delegate;
+            [bridgeDelegate setJsBundleURL:[self codePushBundleURL]];
+        }
+    }
+}
+
+- (NSURL *) codePushBundleURL {
+    NSURL *url = [CodePush bundleURLForResource:@"MiniApp"
+                                  withExtension:@"jsbundle"
+                                   subdirectory:nil
+                                         bundle:[NSBundle bundleForClass:[self class]]];
+    
+    
+    return url;
+}
+
+@end

--- a/plugins/ern_v0.5.0+/react-native-code-push_v5.1.1+/config.json
+++ b/plugins/ern_v0.5.0+/react-native-code-push_v5.1.1+/config.json
@@ -1,0 +1,24 @@
+{
+  "android": {
+    "moduleName": "app",
+    "dependencies": [
+      "com.nimbusds:nimbus-jose-jwt:5.1"
+    ]
+  },
+  "ios": {
+    "copy": [
+      { "source": "ios/**", "dest": "{{{projectName}}}/Libraries/CodePush" }
+    ],
+    "pbxproj": {
+      "addStaticLibrary": [
+        "libz.tbd"
+      ],
+       "addProject": [
+        { "path": "CodePush/CodePush.xcodeproj", "group": "Libraries", "staticLibs": [ { "name": "libCodePush.a", "target": "CodePush" } ] }
+      ],
+      "addHeaderSearchPath": [
+        "\"$(SRCROOT)/{{{projectName}}}/Libraries/CodePush/**\""
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- Add `react-native-code-push` plugin configuration for `v5.1.1-beta+`  
  - Added compile dependency `com.nimbusds:nimbus-jose-jwt:5.1` to plugin configuration for Android
  - No changes in configuration for iOS compared to older version used

- Set target `react-native-code-push` version for `ern 0.7.x` and `ern 1000.0.0` to `5.1.3-beta` (latest CodePush version)
