### PR TITLE
Add config for react-native 0.49.0+

### DIFF
--- a/plugins/ern_v0.5.0+/react-native_v0.49.0+/config.json
+++ b/plugins/ern_v0.5.0+/react-native_v0.49.0+/config.json
@@ -1,0 +1,54 @@
+{
+  "ios": {
+     "copy": [
+      { "source": "React", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "ReactCommon", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/PushNotificationIOS", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/ActionSheetIOS", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/NativeAnimation", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/Geolocation", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/Image", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/LinkingIOS", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/Network", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/Settings", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/Text", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/Vibration", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/WebSocket", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/CameraRoll", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/fishhook", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "scripts", "dest": "{{{projectName}}}/Libraries/ReactNative" }
+    ],
+    "replaceInFile": [
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/React.xcodeproj/project.pbxproj", "string": "../Libraries", "replaceWith": "../" },
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridge.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridge.h", "string": "#import <React/RCTBridgeDelegate.h>", "replaceWith": "#if __has_include(<React/RCTBridgeDelegate.h>)\n#import <React/RCTBridgeDelegate.h>\n#elif __has_include(\"RCTBridgeDelegate.h\")\n#import \"RCTBridgeDelegate.h\"\n#else\n#import \"React/RCTBridgeDelegate.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridge.h", "string": "#import <React/RCTBridgeModule.h>", "replaceWith": "#if __has_include(<React/RCTBridgeModule.h>)\n#import <React/RCTBridgeModule.h>\n#elif __has_include(\"RCTBridgeModule.h\")\n#import \"RCTBridgeModule.h\"\n#else\n#import \"React/RCTBridgeModule.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridge.h", "string": "#import <React/RCTFrameUpdate.h>", "replaceWith": "#if __has_include(<React/RCTFrameUpdate.h>)\n#import <React/RCTFrameUpdate.h>\n#elif __has_include(\"RCTFrameUpdate.h\")\n#import \"RCTFrameUpdate.h\"\n#else\n#import \"React/RCTFrameUpdate.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridge.h", "string": "#import <React/RCTInvalidating.h>", "replaceWith": "#if __has_include(<React/RCTInvalidating.h>)\n#import <React/RCTInvalidating.h>\n#elif __has_include(\"RCTInvalidating.h\")\n#import \"RCTInvalidating.h\"\n#else\n#import \"React/RCTInvalidating.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTAssert.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridgeDelegate.h", "string": "#import <React/RCTJavaScriptLoader.h>", "replaceWith": "#if __has_include(<React/RCTJavaScriptLoader.h>)\n#import <React/RCTJavaScriptLoader.h>\n#elif __has_include(\"RCTJavaScriptLoader.h\")\n#import \"RCTJavaScriptLoader.h\"\n#else\n#import \"React/RCTJavaScriptLoader.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTLog.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTLog.h", "string": "#import <React/RCTAssert.h>", "replaceWith": "#if __has_include(<React/RCTAssert.h>)\n#import <React/RCTAssert.h>\n#elif __has_include(\"RCTAssert.h\")\n#import \"RCTAssert.h\"\n#else\n#import \"React/RCTAssert.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTRootView.h", "string": "#import <React/RCTBridge.h>", "replaceWith": "#if __has_include(<React/RCTBridge.h>)\n#import <React/RCTBridge.h>\n#elif __has_include(\"RCTBridge.h\")\n#import \"RCTBridge.h\"\n#else\n#import \"React/RCTBridge.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Modules/RCTEventEmitter.h", "string": "#import <React/RCTBridge.h>", "replaceWith": "#if __has_include(<React/RCTBridge.h>)\n#import <React/RCTBridge.h>\n#elif __has_include(\"RCTBridge.h\")\n#import \"RCTBridge.h\"\n#else\n#import \"React/RCTBridge.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridgeModule.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTJavaScriptLoader.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"}
+    ],
+    "pbxproj": {
+      "addProject": [
+        { "path": "ReactNative/React/React.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libReact.a", "target": "React" } ] },
+        { "path": "ReactNative/ActionSheetIOS/RCTActionSheet.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTActionSheet.a", "target": "RCTActionSheet" } ] },
+        { "path": "ReactNative/Image/RCTImage.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTImage.a", "target": "RCTImage" } ] },
+        { "path": "ReactNative/NativeAnimation/RCTAnimation.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTAnimation.a", "target": "RCTAnimation" } ] },
+        { "path": "ReactNative/Text/RCTText.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTText.a", "target": "RCTText" } ] },
+        { "path": "ReactNative/WebSocket/RCTWebSocket.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTWebSocket.a", "target": "RCTWebSocket" } ] },
+        { "path": "ReactNative/Geolocation/RCTGeolocation.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTGeolocation.a", "target": "RCTGeolocation" } ] },
+        { "path": "ReactNative/LinkingIOS/RCTLinking.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTLinking.a", "target": "RCTLinking" } ] },
+        { "path": "ReactNative/Network/RCTNetwork.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTNetwork.a", "target": "RCTNetwork" } ] },
+        { "path": "ReactNative/Settings/RCTSettings.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTSettings.a", "target": "RCTSettings" } ] },
+        { "path": "ReactNative/Vibration/RCTVibration.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTVibration.a", "target": "RCTVibration" } ] },
+        { "path": "ReactNative/CameraRoll/RCTCameraRoll.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTCameraRoll.a", "target": "RCTCameraRoll" } ] }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fix proper compilation of Container with React Native `v0.49.0+`, that introduced `fishhook` library on iOS. https://github.com/facebook/react-native/tree/master/Libraries/fishhook