### PR TITLE
 add manifest config for LLImageView for Android

### DIFF
--- a/plugins/ern_v0.5.0+/react-native-llimageview_v0.0.3+/LLImageViewPlugin.java
+++ b/plugins/ern_v0.5.0+/react-native-llimageview_v0.0.3+/LLImageViewPlugin.java
@@ -1,0 +1,18 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import net.livelinktechnology.llimageview.LLImageViewPackage;
+
+public class LLImageViewPlugin {
+
+    public ReactPackage hook(@NonNull Application application,
+                     @NonNull ReactInstanceManagerBuilder reactInstanceManagerBuilder) {
+        LLImageViewPackage llImageViewPackage = new LLImageViewPackage();
+        reactInstanceManagerBuilder.addPackage(llImageViewPackage);
+        return llImageViewPackage;
+    }
+}

--- a/plugins/ern_v0.5.0+/react-native-llimageview_v0.0.3+/config.json
+++ b/plugins/ern_v0.5.0+/react-native-llimageview_v0.0.3+/config.json
@@ -1,5 +1,6 @@
 {
 	"android": {
+		"root": "",
 		"moduleName": "android"
 	},
 	"ios": {

--- a/plugins/ern_v0.5.0+/react-native-llimageview_v0.0.3+/config.json
+++ b/plugins/ern_v0.5.0+/react-native-llimageview_v0.0.3+/config.json
@@ -1,18 +1,27 @@
 {
-  "ios": {
-    "pluginHook": {
-      "configurable": false
-    },
-    "copy": [
-      { "source": "ios/**", "dest": "{{{projectName}}}/Libraries/LLImageView" }
-    ],
-    "pbxproj": {
-       "addProject": [
-        { "path": "LLImageView/LLImageView.xcodeproj", "group": "Libraries", "staticLibs": [ { "name": "libLLImageView.a", "target": "LLImageView" } ] }
-      ],
-      "addHeaderSearchPath": [
-        "\"$(SRCROOT)/{{{projectName}}}/Libraries/LLImageView/**\""
-      ]
-    }
-  }
+	"android": {
+		"moduleName": "android"
+	},
+	"ios": {
+		"pluginHook": {
+			"configurable": false
+		},
+		"copy": [{
+			"source": "ios/**",
+			"dest": "{{{projectName}}}/Libraries/LLImageView"
+		}],
+		"pbxproj": {
+			"addProject": [{
+				"path": "LLImageView/LLImageView.xcodeproj",
+				"group": "Libraries",
+				"staticLibs": [{
+					"name": "libLLImageView.a",
+					"target": "LLImageView"
+				}]
+			}],
+			"addHeaderSearchPath": [
+				"\"$(SRCROOT)/{{{projectName}}}/Libraries/LLImageView/**\""
+			]
+		}
+	}
 }


### PR DESCRIPTION
cd /Users/k0s00ly/.ern/containergen/plugins/node_modules/react-native-llimageview
cp -R android/src/main/java /Users/k0s00ly/.ern/containergen/out/android/lib/src/main
Mustaching lib/src/main/java/net/livelinktechnology/llimageview/BWFilterPostProcessor.java
Mustaching lib/src/main/java/net/livelinktechnology/llimageview/BrightnessFilterPostProcessor.java
Mustaching lib/src/main/java/net/livelinktechnology/llimageview/CombinedPostprocessor.java
Mustaching lib/src/main/java/net/livelinktechnology/llimageview/GammaFilterPostProcessor.java
Mustaching lib/src/main/java/net/livelinktechnology/llimageview/LLImageView.java
Mustaching lib/src/main/java/net/livelinktechnology/llimageview/LLImageViewManager.java
Mustaching lib/src/main/java/net/livelinktechnology/llimageview/LLImageViewPackage.java
Mustaching lib/src/main/java/net/livelinktechnology/llimageview/SepiaFilterPostProcessor.java[=== Completed mini apps bundling ===]
[=== Starting build and publication ===]
[=== Completed build and publication of the module ===]
Published com.walmartlabs.ern:myapp-ern-container:1.0.1
To file:///Users/k0s00ly/.m2/repository
✔ Creating Container for myapp:android:1.0.0 from Cauldron
✔ Updating Cauldron
Published new container version 1.0.1 for myapp:android:1.0.0
MiniApp(s) was/were succesfully added to myapp:android:1.0.0 in the Cauldron