### PR TITLE
Add react-native-camera plugin

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -157,7 +157,8 @@
       "react-native-llphotoassets@0.0.2",
       "react-native-svg@6.2.1",
       "react-native-exif@0.1.7",
-      "react-native-view-shot@2.3.0"
+      "react-native-view-shot@2.3.0",
+      "react-native-camera@1.0.1"
     ],
     "targetJsDependencies": [
       "react@16.2.0"
@@ -178,7 +179,8 @@
       "react-native-llphotoassets@0.0.2",
       "react-native-svg@6.2.1",
       "react-native-exif@0.1.7",
-      "react-native-view-shot@2.3.0"
+      "react-native-view-shot@2.3.0",
+      "react-native-camera@1.0.1"
     ],
     "targetJsDependencies": [
       "react@16.2.0"

--- a/plugins/ern_v0.14.0+/react-native-camera_v1.0.1+/CameraPlugin.java
+++ b/plugins/ern_v0.14.0+/react-native-camera_v1.0.1+/CameraPlugin.java
@@ -1,0 +1,16 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import org.reactnative.camera.RNCameraPackage;
+
+public class CameraPlugin implements ReactPlugin {
+
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new RNCameraPackage();
+    }
+}

--- a/plugins/ern_v0.14.0+/react-native-camera_v1.0.1+/config.json
+++ b/plugins/ern_v0.14.0+/react-native-camera_v1.0.1+/config.json
@@ -1,0 +1,34 @@
+{
+  "android": {
+    "root": "",
+    "moduleName": "android",
+    "dependencies": [
+      "com.google.zxing:core:3.2.1",
+      "com.drewnoakes:metadata-extractor:2.9.1",
+      "com.google.android.gms:play-services-vision:10.2.0",
+      "com.android.support:exifinterface:25.3.1",
+      "com.google:cameraview:d5d9b0d925494ef451ce3eef3fdf14cc874d9baa"
+    ],
+    "permissions": [
+      "android.permission.RECORD_AUDIO",
+      "android.permission.READ_EXTERNAL_STORAGE",
+      "android.permission.WRITE_EXTERNAL_STORAGE"
+    ]
+  },
+  "ios": {
+    "copy": [
+      { "source": "ios/RCT", "dest": "{{{projectName}}}/Libraries/RNCamera" },
+      { "source": "ios/RN", "dest": "{{{projectName}}}/Libraries/RNCamera" },
+      { "source": "ios/RNCamera.xcodeproj", "dest": "{{{projectName}}}/Libraries/RNCamera" },
+      { "source": "postinstall_project/projectWithoutFaceDetection.pbxproj", "dest": "{{{projectName}}}/Libraries/RNCamera/RNCamera.xcodeproj/project.pbxproj" }
+    ],
+    "pbxproj": {
+       "addProject": [
+        { "path": "RNCamera/RNCamera.xcodeproj", "group": "Libraries", "staticLibs": [ { "name": "libRNCamera.a", "target": "RNCamera" } ] }
+      ],
+      "addHeaderSearchPath": [
+        "\"$(SRCROOT)/{{{projectName}}}/Libraries/RNCamera/**\""
+      ]
+    }
+  }
+}

--- a/plugins/ern_v0.14.0+/react-native-camera_v1.0.1+/config.json
+++ b/plugins/ern_v0.14.0+/react-native-camera_v1.0.1+/config.json
@@ -10,7 +10,9 @@
       "com.google:cameraview:d5d9b0d925494ef451ce3eef3fdf14cc874d9baa"
     ],
     "permissions": [
+      "android.permission.CAMERA",
       "android.permission.RECORD_AUDIO",
+      "android.permission.RECORD_VIDEO",
       "android.permission.READ_EXTERNAL_STORAGE",
       "android.permission.WRITE_EXTERNAL_STORAGE"
     ]


### PR DESCRIPTION
This PR adds [react-native-camera v1.0.1](https://github.com/react-native-community/react-native-camera/tree/v1.0.1) as a plugin on master manifest.

It includes FaceDetection feature on Android but not on iOS, because of the [myriad of custom Google libs](https://github.com/react-native-community/react-native-camera/tree/v1.0.1#installing-gmv-frameworks) we'd need to inject on build process.

It depends on platform version 0.14+ to automatically add permissions on AndroidManifest.xml.