### PR TITLE
fix fbsdk config.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -205,7 +205,8 @@
       "react-native-exif@0.1.8",
       "react-native-view-shot@2.3.0",
       "react-native-camera@1.0.2",
-      "react-native-permissions@1.1.1"
+      "react-native-permissions@1.1.1",
+      "react-native-fbsdk@0.7.0"
 
     ],
     "targetJsDependencies": [
@@ -231,7 +232,8 @@
       "react-native-camera@1.0.2",
       "react-native-permissions@1.1.1",
       "react-native-keep-awake@3.0.0",
-      "react-native-location@0.27.0"
+      "react-native-location@0.27.0",
+      "react-native-fbsdk@0.7.0"
     ],
     "targetJsDependencies": [
       "react@16.3.0-alpha.1"

--- a/plugins/ern_v0.13.0+/react-native-fbsdk_v0.5.0+/config.json
+++ b/plugins/ern_v0.13.0+/react-native-fbsdk_v0.5.0+/config.json
@@ -11,6 +11,12 @@
       { "source": "ios/**", "dest": "{{{projectName}}}/Libraries/RCTFBSDK" }
     ],
     "pbxproj": {
+      "addFrameworkReference": [
+          "../../../../Documents/FacebookSDK/Bolts.framework",
+          "../../../../Documents/FacebookSDK/FBSDKCoreKit.framework",
+          "../../../../Documents/FacebookSDK/FBSDKLoginKit.framework",
+          "../../../../Documents/FacebookSDK/FBSDKShareKit.framework"
+        ],
        "addProject": [
         { "path": "RCTFBSDK/RCTFBSDK.xcodeproj", "group": "Libraries", "staticLibs": [ { "name": "libRCTFBSDK.a", "target": "RCTFBSDK" } ] }
       ],


### PR DESCRIPTION
The current FBSDK plugin config.json won't add the plugin successfully. To fix that, the following changes have to be made in config.json 