### PR TITLE
use ~ to get home path instead of relative path

### DIFF
--- a/plugins/ern_v0.13.0+/react-native-fbsdk_v0.5.0+/config.json
+++ b/plugins/ern_v0.13.0+/react-native-fbsdk_v0.5.0+/config.json
@@ -12,10 +12,10 @@
     ],
     "pbxproj": {
       "addFrameworkReference": [
-          "../../../../Documents/FacebookSDK/Bolts.framework",
-          "../../../../Documents/FacebookSDK/FBSDKCoreKit.framework",
-          "../../../../Documents/FacebookSDK/FBSDKLoginKit.framework",
-          "../../../../Documents/FacebookSDK/FBSDKShareKit.framework"
+          "~/Documents/FacebookSDK/Bolts.framework",
+          "~/Documents/FacebookSDK/FBSDKCoreKit.framework",
+          "~/Documents/FacebookSDK/FBSDKLoginKit.framework",
+          "~/Documents/FacebookSDK/FBSDKShareKit.framework"
         ],
        "addProject": [
         { "path": "RCTFBSDK/RCTFBSDK.xcodeproj", "group": "Libraries", "staticLibs": [ { "name": "libRCTFBSDK.a", "target": "RCTFBSDK" } ] }


### PR DESCRIPTION
the `../../../..` had an assumption that ElectrodeContainer is under ~/.ern. That could be problematic for container generated and pushed to git repo and then pulled down. Thus, this is to fix that by the ~ to locate home directory instead of relative path. 