### PR TITLE
include android-maps-utils required for 0.21.0

### DIFF
--- a/plugins/ern_v0.17.0+/react-native-maps_v0.21.0+/MapsPlugin.java
+++ b/plugins/ern_v0.17.0+/react-native-maps_v0.21.0+/MapsPlugin.java
@@ -1,0 +1,17 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.airbnb.android.react.maps.MapsPackage;
+
+public class MapsPlugin implements ReactPlugin {
+
+    public ReactPackage hook(@NonNull Application application,
+                      @Nullable ReactPluginConfig config) {
+        return new MapsPackage();
+    }
+}

--- a/plugins/ern_v0.17.0+/react-native-maps_v0.21.0+/config.json
+++ b/plugins/ern_v0.17.0+/react-native-maps_v0.21.0+/config.json
@@ -1,0 +1,24 @@
+{
+  "android": {
+    "root": "lib",
+    "moduleName": "android",
+    "dependencies": [
+      "com.google.android.gms:play-services-base:10.2.4",
+      "com.google.android.gms:play-services-maps:10.2.4",
+      "com.google.maps.android:android-maps-utils:0.5+"
+    ]
+  },
+  "ios": {
+    "copy": [
+      { "source": "lib/ios/**", "dest": "{{{projectName}}}/Libraries/AirMaps" }
+    ],
+    "pbxproj": {
+       "addProject": [
+        { "path": "AirMaps/AirMaps.xcodeproj", "group": "Libraries", "staticLibs": [ { "name": "libAIRMaps.a", "target": "AirMaps" } ] }
+      ],
+      "addHeaderSearchPath": [
+        "\"$(SRCROOT)/{{{projectName}}}/Libraries/AirMaps/**\""
+      ]
+    }
+  }
+}


### PR DESCRIPTION
include android-maps-utils required for 0.21.0

Excluding `com.google.maps.android:android-maps-utils:0.5+` would lead to compilation errors. 