### PR TITLE
Fix react-native-maps 0.21.0+ for iOS

### DIFF
--- a/plugins/ern_v0.17.0+/react-native-maps_v0.21.0+/config.json
+++ b/plugins/ern_v0.17.0+/react-native-maps_v0.21.0+/config.json
@@ -19,6 +19,9 @@
       "addHeaderSearchPath": [
         "\"$(SRCROOT)/{{{projectName}}}/Libraries/AirMaps/**\""
       ]
-    }
+    },
+    "replaceInFile": [
+      {"path": "{{{projectName}}}/Libraries/AirMaps/AirMaps.xcodeproj/project.pbxproj", "string": "IPHONEOS_DEPLOYMENT_TARGET = 7.0;", "replaceWith": "EXCLUDED_SOURCE_FILE_NAMES = \"AirGoogleMaps/*\";\n\t\t\t\tIPHONEOS_DEPLOYMENT_TARGET = 7.0;"} 
+    ]
   }
 }


### PR DESCRIPTION
This fix react-native-maps 0.21.0 on iOS for AppleMaps provider only. 
GoogleMaps provider is not supported with ElectrodeNative for react-native-maps at this time.
PS : Should think about a plugin configuration directive to inject build settings in a target pbxproj. Using `replaceInFile` for achieving this is not very elegant ... but it does the job.