### PR TITLE
Fix React Native build for XCode 10 support

### DIFF
--- a/plugins/ern_v0.13.0+/react-native_v0.55.4+/config.json
+++ b/plugins/ern_v0.13.0+/react-native_v0.55.4+/config.json
@@ -37,7 +37,8 @@
         { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridgeModule.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
         { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTJavaScriptLoader.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
         { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTUtils.h", "string": "#import <React/RCTAssert.h>", "replaceWith": "#if __has_include(<React/RCTAssert.h>)\n#import <React/RCTAssert.h>\n#elif __has_include(\"RCTAssert.h\")\n#import \"RCTAssert.h\"\n#else\n#import \"React/RCTAssert.h\"\n#endif"},
-        { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTUtils.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"}
+        { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTUtils.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
+        { "path": "{{{projectName}}}/Libraries/ReactNative/WebSocket/RCTWebSocket.xcodeproj/project.pbxproj", "string": "13526A511F362F7F0008EF00", "replaceWith": "3DBE0D001F3B181A0099AA32"}
       ],
       "pbxproj": {
         "addProject": [


### PR DESCRIPTION
Uses the reference for `libfishhook.a` from the Products, rather than the reference from the Frameworks group.
See https://github.com/facebook/react-native/pull/19579/commits/293915091ca6c9de2c54681e78eecf3229bc05d5 for reference