### PR TITLE
lock the com.facebook.android:facebook-android-sdk

### DIFF
--- a/plugins/ern_v0.13.0+/react-native-fbsdk_v0.5.0+/config.json
+++ b/plugins/ern_v0.13.0+/react-native-fbsdk_v0.5.0+/config.json
@@ -3,7 +3,7 @@
     "root": "",
     "moduleName": "android",
     "dependencies": [
-      "com.facebook.android:facebook-android-sdk:4.+"
+      "com.facebook.android:facebook-android-sdk:4.37.0"
     ]
   },
   "ios": {

--- a/plugins/ern_v0.5.0+/react-native-fbsdk_v0.5.0+/config.json
+++ b/plugins/ern_v0.5.0+/react-native-fbsdk_v0.5.0+/config.json
@@ -3,7 +3,7 @@
     "root": "",
     "moduleName": "android",
     "dependencies": [
-      "com.facebook.android:facebook-android-sdk:4.+"
+      "com.facebook.android:facebook-android-sdk:4.37.0"
     ]
   },
   "ios": {


### PR DESCRIPTION
https://search.maven.org/search?q=g:com.facebook.android%20AND%20a:facebook-android-sdk&core=gav
`facebook-android-sdk` released on Oct 23 , `4.38.0` , introduces a breaking change in the AccessToken signature.

```
05:55:32 ✖ /private/var/folders/r6/sglv7kg9419225dgxzcn1rgh0000j_/T/tmp-53834z5o0RzC47lAF/lib/src/main/java/com/facebook/reactnative/androidsdk/FBGraphRequestModule.java:155: error: no suitable constructor found for AccessToken(String,String,String,<null>,<null>,<null>,<null>,<null>)
05:55:32 ✖             graphRequest.setAccessToken(new AccessToken(
05:55:32 ✖                                         ^
05:55:32 ✖     constructor AccessToken.AccessToken(String,String,String,Collection<String>,Collection<String>,AccessTokenSource,Date,Date,Date) is not applicable
05:55:32 ✖       (actual and formal argument lists differ in length)
05:55:32 ✖     constructor AccessToken.AccessToken(Parcel) is not applicable
05:55:32 ✖       (actual and formal argument lists differ in length)
05:55:32 ✖ /private/var/folders/r6/sglv7kg9419225dgxzcn1rgh0000j_/T/tmp-53834z5o0RzC47lAF/lib/src/main/java/com/facebook/reactnative/androidsdk/Utility.java:64: error: no suitable constructor found for AccessToken(String,String,String,List<String>,List<String>,AccessTokenSource,Date,Date)
05:55:32 ✖         return new AccessToken(
05:55:32 ✖                ^
05:55:32 ✖     constructor AccessToken.AccessToken(String,String,String,Collection<String>,Collection<String>,AccessTokenSource,Date,Date,Date) is not applicable
05:55:32 ✖       (actual and formal argument lists differ in length)
```