### PR TITLE
add support for appcenter-analytics android [android]

### DIFF
--- a/plugins/ern_v0.14.0+/appcenter-analytics_v1.11.0+/AppCenterReactNativeAnalyticsPlugin.java
+++ b/plugins/ern_v0.14.0+/appcenter-analytics_v1.11.0+/AppCenterReactNativeAnalyticsPlugin.java
@@ -1,0 +1,39 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.microsoft.appcenter.reactnative.analytics.AppCenterReactNativeAnalyticsPackage;
+
+public class AppCenterReactNativeAnalyticsPlugin implements ReactPlugin<AppCenterReactNativeAnalyticsPlugin.Config> {
+
+    public ReactPackage hook(@NonNull Application application,
+                             @Nullable Config config) {
+        if (config != null && config.enableInJs != null) {
+            return new AppCenterReactNativeAnalyticsPackage(application, config.enableInJs);
+        }
+        boolean enableDebugMode = false;
+        if (config != null && config.enableDebugMode) {
+            enableDebugMode = true;
+        }
+        return new AppCenterReactNativeAnalyticsPackage(application, enableDebugMode);
+    }
+
+    public static class Config implements ReactPluginConfig {
+        private boolean enableDebugMode;
+        private String enableInJs;
+
+        public Config enableDebugMode(boolean enableDebugMode) {
+            this.enableDebugMode = enableDebugMode;
+            return this;
+        }
+
+        public Config enableInJs(String enableInJs) {
+            this.enableInJs = enableInJs;
+            return this;
+        }
+    }
+}

--- a/plugins/ern_v0.14.0+/appcenter-analytics_v1.11.0+/config.json
+++ b/plugins/ern_v0.14.0+/appcenter-analytics_v1.11.0+/config.json
@@ -1,0 +1,10 @@
+{
+	"android": {
+		"root": "",
+		"moduleName": "android",
+		"dependencies": [
+			"com.microsoft.appcenter:appcenter-analytics:1.11.0",
+			"com.microsoft.appcenter.reactnative:appcenter-react-native:1.11.0"
+		]
+	}
+}


### PR DESCRIPTION
add support for appcenter-analytics android
https://github.com/Microsoft/AppCenter-SDK-React-Native/tree/develop/appcenter-analytics