### PR TITLE
Rollback change to versions of play services base for react-native-maps

### DIFF
--- a/plugins/ern_v0.14.0+/react-native-maps_v0.21.0+/config.json
+++ b/plugins/ern_v0.14.0+/react-native-maps_v0.21.0+/config.json
@@ -3,8 +3,8 @@
     "root": "lib",
     "moduleName": "android",
     "dependencies": [
-      "com.google.android.gms:play-services-base:16.0.0",
-      "com.google.android.gms:play-services-maps:16.0.0",
+      "com.google.android.gms:play-services-base:10.2.4",
+      "com.google.android.gms:play-services-maps:10.2.4",
       "com.google.maps.android:android-maps-utils:0.5+"
     ]
   },

--- a/plugins/ern_v0.14.0+/react-native-maps_v0.22.1+/config.json
+++ b/plugins/ern_v0.14.0+/react-native-maps_v0.22.1+/config.json
@@ -3,8 +3,8 @@
     "root": "lib",
     "moduleName": "android",
     "dependencies": [
-      "com.google.android.gms:play-services-base:16.0.0",
-      "com.google.android.gms:play-services-maps:16.0.0",
+      "com.google.android.gms:play-services-base:11.4.0",
+      "com.google.android.gms:play-services-maps:11.4.0",
       "com.google.maps.android:android-maps-utils:0.5+"
     ]
   },


### PR DESCRIPTION
Rolling back these two commits 

https://github.com/electrode-io/electrode-native-manifest/commit/3f90ab861efd465c5afdd9e901520bdc14da5391

https://github.com/electrode-io/electrode-native-manifest/commit/02b3ea612743f8143547cccd2a99dd774207060d