### PR TITLE
Add Realm plugin support for Android

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -727,7 +727,8 @@
       "react-native-orientation@3.1.3",
       "react-native-sound@0.10.12",
       "react-native-sentry@0.41.1",
-      "react-native-admob@2.0.0-beta.5"
+      "react-native-admob@2.0.0-beta.5",
+      "realm@2.27.0"
     ],
     "targetJsDependencies": ["react@16.8.3"]
   },
@@ -772,7 +773,8 @@
       "react-native-orientation@3.1.3",
       "react-native-sound@0.10.12",
       "react-native-sentry@0.41.1",
-      "react-native-admob@2.0.0-beta.5"
+      "react-native-admob@2.0.0-beta.5",
+      "realm@2.27.0"
     ],
     "targetJsDependencies": ["react@16.8.3"]
   }

--- a/plugins/ern_v0.14.0+/realm_v2.27.0+/README.md
+++ b/plugins/ern_v0.14.0+/realm_v2.27.0+/README.md
@@ -1,0 +1,8 @@
+## [Realm](https://realm.io) Plugin
+
+This plugin is only supported on Android.  
+We are working on iOS support.
+
+Demo MiniApp : [ern-realm-demo-miniapp](https://github.com/belemaire/ern-realm-demo-miniapp) 
+
+The demo repository also contains **important remarks** to account for, if you are planning to add this plugin to a MiniApp.

--- a/plugins/ern_v0.14.0+/realm_v2.27.0+/RealmPlugin.java
+++ b/plugins/ern_v0.14.0+/realm_v2.27.0+/RealmPlugin.java
@@ -1,0 +1,16 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import io.realm.react.RealmReactPackage;
+
+public class RealmPlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application,
+                             @Nullable ReactPluginConfig config) {
+        return new RealmReactPackage();
+    }
+}

--- a/plugins/ern_v0.14.0+/realm_v2.27.0+/config.json
+++ b/plugins/ern_v0.14.0+/realm_v2.27.0+/config.json
@@ -1,0 +1,8 @@
+{
+    "android": {
+      "root": "android",
+      "dependencies": [
+        "org.nanohttpd:nanohttpd:2.2.0"
+      ]
+    }
+}


### PR DESCRIPTION
Initial [Realm](https://realm.io) plugin support. Android only.