### PR TITLE
[iOS] react-native-version-number

### DIFF
--- a/plugins/ern_v0.14.0+/react-native-version-number_v0.3.4+/config.json
+++ b/plugins/ern_v0.14.0+/react-native-version-number_v0.3.4+/config.json
@@ -2,5 +2,24 @@
 	"android": {
 		"root": "",
 		"moduleName": "android"
+	},
+	"ios": {
+		"copy": [{
+			"source": "ios/*",
+			"dest": "{{{projectName}}}/Libraries/RNVersionNumber"
+		}],
+		"pbxproj": {
+			"addProject": [{
+				"path": "RNVersionNumber/RNVersionNumber.xcodeproj",
+				"group": "Libraries",
+				"staticLibs": [{
+					"name": "libRNVersionNumber.a",
+					"target": "RNVersionNumber"
+				}]
+			}],
+			"addHeaderSearchPath": [
+				"\"$(SRCROOT)/{{{projectName}}}/Libraries/RNVersionNumber/**\""
+			]
+		}
 	}
 }


### PR DESCRIPTION
Issue electrode-io/electrode-native-manifest#75

We've switch to rn-device-info, but were using this config successfully for a while.