### PR TITLE
WIP: react-native-gesture-handler

### DIFF
--- a/plugins/ern_v0.14.0+/react-native-gesture-handler_v1.0.15+/GestureHandlerPlugin.java
+++ b/plugins/ern_v0.14.0+/react-native-gesture-handler_v1.0.15+/GestureHandlerPlugin.java
@@ -1,0 +1,23 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
+
+public class GestureHandlerPlugin implements ReactPlugin {
+
+  public ReactPackage hook(
+    @NonNull
+    Application application,
+    @Nullable
+    ReactPluginConfig config
+  ) {
+    return new RNGestureHandlerPackage();
+  }
+
+}
+

--- a/plugins/ern_v0.14.0+/react-native-gesture-handler_v1.0.15+/config.json
+++ b/plugins/ern_v0.14.0+/react-native-gesture-handler_v1.0.15+/config.json
@@ -1,0 +1,49 @@
+{
+  "android": {
+    "root": "",
+    "moduleName": "android",
+    "copy": [
+      {
+        "source": "android/lib/src/main/java/**",
+        "dest": "lib/src/main/java"
+      }
+    ],
+    "replaceInFile": [
+      {
+        "path": "lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java",
+        "string": "import com.facebook.react.ReactRootView;",
+        "replaceWith": "import com.facebook.react.ReactRootView;\nimport com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;"
+      },
+      {
+        "path": "lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java",
+        "string": "    }\n}",
+        "replaceWith": "    }\n\n    @Override\n    protected ReactRootView createRootView() {\n        return new RNGestureHandlerEnabledRootView(getContext());\n    }\n}"
+      }
+    ]
+  },
+  "ios": {
+    "copy": [
+      {
+        "source": "ios/**",
+        "dest": "{{{projectName}}}/Libraries/RNGestureHandler"
+      }
+    ],
+    "pbxproj": {
+      "addProject": [
+        {
+          "path": "RNGestureHandler/RNGestureHandler.xcodeproj",
+          "group": "Libraries",
+          "staticLibs": [
+            {
+              "name": "libRNGestureHandler.a",
+              "target": "RNGestureHandler"
+            }
+          ]
+        }
+      ],
+      "addHeaderSearchPath": [
+        "\"$(SRCROOT)/{{{projectName}}}/Libraries/RNGestureHandler/**\""
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Another staple react-native plugin -

This is a **WIP** -- it can't be merged as-is until this issue is resolved: electrode-io/electrode-native#1060 **because it uses `relaceInFile` on Android** (currently not supported)

RN-gesture-handler has a [slightly involved installation process](https://kmagiera.github.io/react-native-gesture-handler/docs/getting-started.html):

> Update your MainActivity.java file (or wherever you create an instance of ReactActivityDelegate)

In our case, that means adding the edited `createRootView` to [ElectrodeReactActivityDelegate.java](https://github.com/electrode-io/electrode-native/blob/master/ern-container-gen-android/src/hull/lib/src/main/java/com/walmartlabs/ern/container/ElectrodeReactActivityDelegate.java)

2 replacements are made:

1. Adding the `RNGestureHandlerEnabledRootView` import
2. `@Override`ing the `createRootView` method:
    * The search uses a brittle matcher to find the end of the class: `<four spaces>}\n}`, which depends on code style/indentation. Not great..
  
