### PR TITLE
upgrade the bridge version in manifest @1.5.19

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -601,7 +601,7 @@
     "platformVersion": "0.30.x",
     "targetNativeDependencies": [
       "react-native@0.59.2",
-      "react-native-electrode-bridge@1.5.17",
+      "react-native-electrode-bridge@1.5.19",
       "react-native-maps@0.23.0",
       "react-native-vector-icons@6.3.0",
       "react-native-linear-gradient@2.5.3",
@@ -645,7 +645,7 @@
     "platformVersion": "0.31.x",
     "targetNativeDependencies": [
       "react-native@0.59.4",
-      "react-native-electrode-bridge@1.5.17",
+      "react-native-electrode-bridge@1.5.19",
       "react-native-maps@0.23.0",
       "react-native-vector-icons@6.3.0",
       "react-native-linear-gradient@2.5.4",
@@ -690,7 +690,7 @@
     "platformVersion": "0.32.x",
     "targetNativeDependencies": [
       "react-native@0.59.4",
-      "react-native-electrode-bridge@1.5.17",
+      "react-native-electrode-bridge@1.5.19",
       "react-native-maps@0.23.0",
       "react-native-vector-icons@6.3.0",
       "react-native-linear-gradient@2.5.4",
@@ -739,7 +739,7 @@
     "platformVersion": "0.33.x",
     "targetNativeDependencies": [
       "react-native@0.59.8",
-      "react-native-electrode-bridge@1.5.17",
+      "react-native-electrode-bridge@1.5.19",
       "react-native-maps@0.23.0",
       "react-native-vector-icons@6.3.0",
       "react-native-linear-gradient@2.5.4",
@@ -788,7 +788,7 @@
     "platformVersion": "0.34.x",
     "targetNativeDependencies": [
       "react-native@0.59.8",
-      "react-native-electrode-bridge@1.5.17",
+      "react-native-electrode-bridge@1.5.19",
       "react-native-maps@0.24.2",
       "react-native-vector-icons@6.5.0",
       "react-native-linear-gradient@2.5.4",
@@ -837,7 +837,7 @@
     "platformVersion": "1000.0.0",
     "targetNativeDependencies": [
       "react-native@0.59.8",
-      "react-native-electrode-bridge@1.5.17",
+      "react-native-electrode-bridge@1.5.19",
       "react-native-maps@0.24.2",
       "react-native-vector-icons@6.5.0",
       "react-native-linear-gradient@2.5.4",


### PR DESCRIPTION
✖ An error occurred: [Transitive Dependency] react-native-electrode-bridge@1.5.19 was not added to the MiniApp