### PR TITLE
Add ios config for rn 0.60.5+

### DIFF
--- a/plugins/ern_v0.13.0+/react-native_v0.60.5+/config.json
+++ b/plugins/ern_v0.13.0+/react-native_v0.60.5+/config.json
@@ -1,0 +1,62 @@
+{
+  "ios": {
+     "copy": [
+      { "source": "React", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "ReactCommon", "dest": "{{{projectName}}}/Libraries/ReactNative" },         
+      { "source": "Libraries/PushNotificationIOS", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/ActionSheetIOS", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/NativeAnimation", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/Image", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/LinkingIOS", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/Network", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/Settings", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/Text", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/Vibration", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/WebSocket", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/CameraRoll", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "Libraries/ART", "dest": "{{{projectName}}}/Libraries/ReactNative" },
+      { "source": "scripts", "dest": "{{{projectName}}}/Libraries/ReactNative" }
+    ],
+    "replaceInFile": [
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/React.xcodeproj/project.pbxproj", "string": "../Libraries", "replaceWith": "../" },
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/React.xcodeproj/project.pbxproj", "string": "006B79A01A781F38006873D1 \/\\* Start Packager \\*\/,", "replaceWith": "" },
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridge.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridge.h", "string": "#import <React/RCTBridgeDelegate.h>", "replaceWith": "#if __has_include(<React/RCTBridgeDelegate.h>)\n#import <React/RCTBridgeDelegate.h>\n#elif __has_include(\"RCTBridgeDelegate.h\")\n#import \"RCTBridgeDelegate.h\"\n#else\n#import \"React/RCTBridgeDelegate.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridge.h", "string": "#import <React/RCTBridgeModule.h>", "replaceWith": "#if __has_include(<React/RCTBridgeModule.h>)\n#import <React/RCTBridgeModule.h>\n#elif __has_include(\"RCTBridgeModule.h\")\n#import \"RCTBridgeModule.h\"\n#else\n#import \"React/RCTBridgeModule.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridge.h", "string": "#import <React/RCTFrameUpdate.h>", "replaceWith": "#if __has_include(<React/RCTFrameUpdate.h>)\n#import <React/RCTFrameUpdate.h>\n#elif __has_include(\"RCTFrameUpdate.h\")\n#import \"RCTFrameUpdate.h\"\n#else\n#import \"React/RCTFrameUpdate.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridge.h", "string": "#import <React/RCTInvalidating.h>", "replaceWith": "#if __has_include(<React/RCTInvalidating.h>)\n#import <React/RCTInvalidating.h>\n#elif __has_include(\"RCTInvalidating.h\")\n#import \"RCTInvalidating.h\"\n#else\n#import \"React/RCTInvalidating.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTAssert.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridgeDelegate.h", "string": "#import <React/RCTJavaScriptLoader.h>", "replaceWith": "#if __has_include(<React/RCTJavaScriptLoader.h>)\n#import <React/RCTJavaScriptLoader.h>\n#elif __has_include(\"RCTJavaScriptLoader.h\")\n#import \"RCTJavaScriptLoader.h\"\n#else\n#import \"React/RCTJavaScriptLoader.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTLog.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTLog.h", "string": "#import <React/RCTAssert.h>", "replaceWith": "#if __has_include(<React/RCTAssert.h>)\n#import <React/RCTAssert.h>\n#elif __has_include(\"RCTAssert.h\")\n#import \"RCTAssert.h\"\n#else\n#import \"React/RCTAssert.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTLog.h", "string": "#import <React/RCTUtils.h>", "replaceWith": "#if __has_include(<React/RCTUtils.h>)\n#import <React/RCTUtils.h>\n#elif __has_include(\"RCTUtils.h\")\n#import \"RCTUtils.h\"\n#else\n#import \"React/RCTUtils.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTRootView.h", "string": "#import <React/RCTBridge.h>", "replaceWith": "#if __has_include(<React/RCTBridge.h>)\n#import <React/RCTBridge.h>\n#elif __has_include(\"RCTBridge.h\")\n#import \"RCTBridge.h\"\n#else\n#import \"React/RCTBridge.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Modules/RCTEventEmitter.h", "string": "#import <React/RCTBridge.h>", "replaceWith": "#if __has_include(<React/RCTBridge.h>)\n#import <React/RCTBridge.h>\n#elif __has_include(\"RCTBridge.h\")\n#import \"RCTBridge.h\"\n#else\n#import \"React/RCTBridge.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTBridgeModule.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTJavaScriptLoader.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTUtils.h", "string": "#import <React/RCTAssert.h>", "replaceWith": "#if __has_include(<React/RCTAssert.h>)\n#import <React/RCTAssert.h>\n#elif __has_include(\"RCTAssert.h\")\n#import \"RCTAssert.h\"\n#else\n#import \"React/RCTAssert.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/React/Base/RCTUtils.h", "string": "#import <React/RCTDefines.h>", "replaceWith": "#if __has_include(<React/RCTDefines.h>)\n#import <React/RCTDefines.h>\n#elif __has_include(\"RCTDefines.h\")\n#import \"RCTDefines.h\"\n#else\n#import \"React/RCTDefines.h\"\n#endif"},
+      { "path": "{{{projectName}}}/Libraries/ReactNative/WebSocket/RCTReconnectingWebSocket.m", "string": "- \\(void\\)webSocket:\\(RCTSRWebSocket \\*\\)webSocket didFailWithError:\\(NSError \\*\\)error\n{\n  \\[_delegate reconnectingWebSocketDidClose:self\\];\n  \\[self reconnect\\];", "replaceWith": "- (void)webSocket:(RCTSRWebSocket *)webSocket didFailWithError:(NSError *)error\n{\n  [_delegate reconnectingWebSocketDidClose:self];\n  if ([error code] != ECONNREFUSED) {\n    [self reconnect];\n  }"}
+    ],
+    "pbxproj": {
+      "addProject": [
+        { "path": "ReactNative/React/React.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libReact.a", "target": "React" } ] },
+        { "path": "ReactNative/ActionSheetIOS/RCTActionSheet.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTActionSheet.a", "target": "RCTActionSheet" } ] },
+        { "path": "ReactNative/Image/RCTImage.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTImage.a", "target": "RCTImage" } ] },
+        { "path": "ReactNative/NativeAnimation/RCTAnimation.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTAnimation.a", "target": "RCTAnimation" } ] },
+        { "path": "ReactNative/Text/RCTText.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTText.a", "target": "RCTText" } ] },
+        { "path": "ReactNative/WebSocket/RCTWebSocket.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTWebSocket.a", "target": "RCTWebSocket" } ] },
+        { "path": "ReactNative/LinkingIOS/RCTLinking.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTLinking.a", "target": "RCTLinking" } ] },
+        { "path": "ReactNative/Network/RCTNetwork.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTNetwork.a", "target": "RCTNetwork" } ] },
+        { "path": "ReactNative/Settings/RCTSettings.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTSettings.a", "target": "RCTSettings" } ] },
+        { "path": "ReactNative/Vibration/RCTVibration.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTVibration.a", "target": "RCTVibration" } ] },
+        { "path": "ReactNative/CameraRoll/RCTCameraRoll.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libRCTCameraRoll.a", "target": "RCTCameraRoll" } ] },
+        { "path": "ReactNative/ART/ART.xcodeproj", "group": "ReactNative", "staticLibs": [ { "name": "libART.a", "target": "ART" } ] }
+      ],
+      "addFrameworkReference": [
+        "/System/Library/Frameworks/JavaScriptCore.framework"
+      ]
+    }
+  }
+}
+


### PR DESCRIPTION
Similar with React Native 0.58.5+ configuration but for the following differences:

- Remove copy/add project step for GeoLocation library as it [was removed from React Native in 0.60.0](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#removed)
- Remove copy step for fishhook library as it [was removed from React Native in 0.60.5](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#ios-specific)