### PR TITLE
Update react-native to 0.60.5 for dev platform

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -988,7 +988,7 @@
   {
     "platformVersion": "1000.0.0",
     "targetNativeDependencies": [
-      "react-native@0.59.10",
+      "react-native@0.60.5",
       "react-native-electrode-bridge@1.5.19",
       "react-native-maps@0.24.2",
       "react-native-vector-icons@6.5.0",
@@ -1033,6 +1033,6 @@
       "@react-native-community/netinfo@3.2.1",
       "@react-native-community/geolocation@2.0.2"
     ],
-    "targetJsDependencies": ["react@16.8.3"]
+    "targetJsDependencies": ["react@16.8.6"]
   }
 ]


### PR DESCRIPTION
I'm not 100% sure at which point we should update the dependencies of the 1000.0.0 platform version, but right now when creating a brand new ern miniapp (using v1000.0.0) `ern run-android` is failing with a compile error.

@belemaire @krunalsshah - Please advise if this should be merged now, or if anything else is needed as a prerequisite.