### PR TITLE
Rollback dev platform React Native version to 0.60.5

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -989,7 +989,7 @@
   {
     "platformVersion": "1000.0.0",
     "targetNativeDependencies": [
-      "react-native@0.61.1",
+      "react-native@0.60.5",
       "react-native-electrode-bridge@1.5.19",
       "react-native-maps@0.24.2",
       "react-native-vector-icons@6.5.0",
@@ -1035,6 +1035,6 @@
       "@react-native-community/netinfo@3.2.1",
       "@react-native-community/geolocation@2.0.2"
     ],
-    "targetJsDependencies": ["react@16.9.0"]
+    "targetJsDependencies": ["react@16.8.6"]
   }
 ]


### PR DESCRIPTION
Unfortunately after running system test regeneration I noticed that iOS Container generation was now failing :( Should have been more careful and tried it locally first.

Failure is due to the fact that React Native [moved away from `.xcodeproj]( https://github.com/facebook/react-native/pull/25583/files) for ReactNative project and all core ReactNative library projects, starting in React Native 0.61.0, in favor of CocoaPods.

Because iOS Container generation is expecting to have these `.xcodeproj` files present to link against them, it it now failing.

There is no quick fix for this one, we will have to look into linking these projects in the iOS Container as CocoaPods rather than directly as .xcodeproj ...