### PR TITLE
add support for react-native-fbsdk 1.0.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1068,7 +1068,6 @@
       "react-native-permissions@1.1.1",
       "react-native-keep-awake@4.0.0",
       "react-native-location@1.0.0",
-      "react-native-fbsdk@0.8.0",
       "react-native-electrode-ota@0.0.1",
       "react-native-image-picker@0.28.1",
       "react-native-search-bar@3.4.2",
@@ -1095,7 +1094,8 @@
       "react-native-fast-image@5.4.2",
       "@react-native-community/async-storage@1.6.1",
       "@react-native-community/netinfo@3.2.1",
-      "@react-native-community/geolocation@2.0.2"
+      "@react-native-community/geolocation@2.0.2",
+      "react-native-fbsdk@1.0.4"
     ],
     "targetJsDependencies": [
       "react@16.8.6"
@@ -1121,7 +1121,6 @@
       "react-native-permissions@1.1.1",
       "react-native-keep-awake@4.0.0",
       "react-native-location@1.0.0",
-      "react-native-fbsdk@0.8.0",
       "react-native-electrode-ota@0.0.1",
       "react-native-image-picker@0.28.1",
       "react-native-search-bar@3.4.2",
@@ -1148,7 +1147,8 @@
       "react-native-fast-image@5.4.2",
       "@react-native-community/async-storage@1.6.1",
       "@react-native-community/netinfo@3.2.1",
-      "@react-native-community/geolocation@2.0.2"
+      "@react-native-community/geolocation@2.0.2",
+      "react-native-fbsdk@1.0.4"
     ],
     "targetJsDependencies": [
       "react@16.8.6"

--- a/plugins/ern_v0.14.0+/react-native-fbsdk_v1.0.4+/FacebookSdkPlugin.java
+++ b/plugins/ern_v0.14.0+/react-native-fbsdk_v1.0.4+/FacebookSdkPlugin.java
@@ -1,0 +1,36 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.FacebookSdk;
+import com.facebook.reactnative.androidsdk.FBSDKPackage;
+
+public class FacebookSdkPlugin implements ReactPlugin<FacebookSdkPlugin.Config> {
+
+    @Override
+    public ReactPackage hook(@NonNull Application application,
+                     @NonNull Config config) {
+        FacebookSdk.setAutoLogAppEventsEnabled(config.autoLogAppEventsEnabled);
+        FacebookSdk.setApplicationId(config.appId);
+        FacebookSdk.sdkInitialize(application);
+        return new FBSDKPackage();
+    }
+
+    public static class Config implements ReactPluginConfig {
+        private String appId;
+        private boolean autoLogAppEventsEnabled;
+
+        public Config(@NonNull String appId) {
+            this.appId = appId;
+            this.autoLogAppEventsEnabled = false;
+        }
+
+        public Config autoLogAppEventsEnabled(boolean autoLogAppEventsEnabled) {
+            this.autoLogAppEventsEnabled = autoLogAppEventsEnabled;
+            return this;
+        }
+    }
+}

--- a/plugins/ern_v0.14.0+/react-native-fbsdk_v1.0.4+/config.json
+++ b/plugins/ern_v0.14.0+/react-native-fbsdk_v1.0.4+/config.json
@@ -1,0 +1,41 @@
+{
+  "android": {
+    "root": "android",
+    "dependencies": [
+      "com.facebook.android:facebook-core:[5,6)",
+      "com.facebook.android:facebook-login:[5,6)",
+      "com.facebook.android:facebook-share:[5,6)"
+    ]
+  },
+  "ios": {
+    "copy": [
+      {
+        "dest": "{{{projectName}}}/Libraries/RCTFBSDK",
+        "source": "ios/**"
+      }
+    ],
+    "pbxproj": {
+      "addFrameworkReference": [
+          "~/Documents/FacebookSDK/Bolts.framework",
+          "~/Documents/FacebookSDK/FBSDKCoreKit.framework",
+          "~/Documents/FacebookSDK/FBSDKLoginKit.framework",
+          "~/Documents/FacebookSDK/FBSDKShareKit.framework"
+        ],
+      "addHeaderSearchPath": [
+        "\"$(SRCROOT)/{{{projectName}}}/Libraries/RCTFBSDK/**\""
+      ],
+      "addProject": [
+        {
+          "group": "Libraries",
+          "path": "RCTFBSDK/RCTFBSDK.xcodeproj",
+          "staticLibs": [
+            {
+              "name": "libRCTFBSDK.a",
+              "target": "RCTFBSDK"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
:zap: add support for react-native-fbsdk 1.0.4

@gmbharath12 @liulianci 
Please review the iOS configuration
https://github.com/facebook/react-native-fbsdk/blob/master/ios/RCTFBSDK.xcodeproj/project.pbxproj#L47

@belemaire 
https://github.com/facebook/react-native-fbsdk/blob/v1.0.4/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java#L33
`FBActivityEventListener` now abstracts `private CallbackManager mCallbackManager = CallbackManager.Factory.create();`