### PR TITLE
Update react-native to 0.60.6 (dev)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1104,7 +1104,7 @@
   {
     "platformVersion": "1000.0.0",
     "targetNativeDependencies": [
-      "react-native@0.60.5",
+      "react-native@0.60.6",
       "react-native-electrode-bridge@1.5.19",
       "react-native-maps@0.24.2",
       "react-native-vector-icons@6.5.0",


### PR DESCRIPTION
Update dev platform to use the latest `0.60.x` version.

`0.60.6` contains one small fix compared to `0.60.5`: https://github.com/facebook/react-native/commit/b6f6c5080ee258c0371c4ed9789816d9d63b8ad2