### PR TITLE
Update react-native-electrode-bridge to 1.5.24

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1220,7 +1220,7 @@
     "platformVersion": "1000.0.0",
     "targetNativeDependencies": [
       "react-native@0.60.6",
-      "react-native-electrode-bridge@1.5.23",
+      "react-native-electrode-bridge@1.5.24",
       "react-native-maps@0.24.2",
       "react-native-vector-icons@6.5.0",
       "react-native-linear-gradient@2.5.4",


### PR DESCRIPTION
`1.5.24` was released on Apr 8, and is expected by the system tests of electrode-native on the master branch.