### PR TITLE
Add react-native-camera v3.24.0+ support for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ in which to store the configuration might look puzzling at first.
 To know which directory to use for a new plugin configuration, just go through
 the following bullet points from top to bottom.
 
+- Does your plugin configuration need to add Android resources (from a `res` directory) to the container or to add iOS resources to the container ?\
+Use `ern_v0.41.1+`
+
 - Does your plugin configuration use `features` directive for Android, `addEmbeddedFramework` directive for iOS, or `applyPatch` directive?\
 Use `ern_v0.39.0+`
 

--- a/plugins/ern_v0.41.1+/react-native-camera_v3.24.0+/CameraPlugin.java
+++ b/plugins/ern_v0.41.1+/react-native-camera_v3.24.0+/CameraPlugin.java
@@ -1,0 +1,14 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactPackage;
+import org.reactnative.camera.RNCameraPackage;
+
+public class CameraPackagePlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new RNCameraPackage();
+    }
+}

--- a/plugins/ern_v0.41.1+/react-native-camera_v3.24.0+/README.md
+++ b/plugins/ern_v0.41.1+/react-native-camera_v3.24.0+/README.md
@@ -1,0 +1,22 @@
+# react-native-camera plugin
+
+Plugin configuration for [react-native-camera](https://github.com/react-native-community/react-native-camera)
+
+
+This configuration is using the `general` product flavor of this native module (using google `play-services-vision` under the hood).
+
+The required `android.permission.CAMERA` is defined in the configuration and will be injected by default.
+
+**If you need to enable the video recording feature of this plugin** you can either add the following permissions in your application `AndroidManifest.xml`
+
+```java
+  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  ```
+
+Alternatively, you can also override this configuration in your own manifest to add the additional permissions to the `permissions` array of the plugin configuration.
+
+**If you want to use the MLKit flavor rather than the general one** then you should override this configuration in your own manifest and replace the [`config.json`])(./config.json) file with the [`config-mlkit.json`](./config-mlkit.json) file.
+
+**If you need other versions of listed dependencies** then you should override this configuration in your own manifest and update the versions at your convenience.

--- a/plugins/ern_v0.41.1+/react-native-camera_v3.24.0+/config-mlkit.json
+++ b/plugins/ern_v0.41.1+/react-native-camera_v3.24.0+/config-mlkit.json
@@ -1,0 +1,37 @@
+{
+  "android": {
+    "root": "android",
+    "dependencies": [
+      "com.google.zxing:core:3.3.3",
+      "com.drewnoakes:metadata-extractor:2.11.0",
+      "com.google.firebase:firebase-ml-vision:19.0.3",
+      "com.google.firebase:firebase-ml-vision-face-model:17.0.2",
+      "androidx.exifinterface:exifinterface:1.0.0",
+      "androidx.annotation:annotation:1.0.0",
+      "androidx.legacy:legacy-support-v4:1.0.0"
+    ],
+    "permissions": ["android.permission.CAMERA"],
+    "copy": [
+      {
+        "source": "android/src/mlkit/java/org/*",
+        "dest": "lib/src/main/java/org"
+      },
+      {
+        "source": "android/src/main/res/*",
+        "dest": "lib/src/main/res/camera"
+      }
+    ],
+    "replaceInFile": [
+      {
+        "path": "lib/src/main/java/com/google/android/cameraview/SurfaceViewPreview.java",
+        "string": "org.reactnative.camera.R",
+        "replaceWith": "com.walmartlabs.ern.container.R"
+      },
+      {
+        "path": "lib/src/main/java/com/google/android/cameraview/TextureViewPreview.java",
+        "string": "org.reactnative.camera.R",
+        "replaceWith": "com.walmartlabs.ern.container.R"
+      }
+    ]
+  }
+}

--- a/plugins/ern_v0.41.1+/react-native-camera_v3.24.0+/config.json
+++ b/plugins/ern_v0.41.1+/react-native-camera_v3.24.0+/config.json
@@ -1,0 +1,36 @@
+{
+  "android": {
+    "root": "android",
+    "dependencies": [
+      "com.google.zxing:core:3.3.3",
+      "com.drewnoakes:metadata-extractor:2.11.0",
+      "com.google.android.gms:play-services-vision:17.0.2",
+      "androidx.exifinterface:exifinterface:1.0.0",
+      "androidx.annotation:annotation:1.0.0",
+      "androidx.legacy:legacy-support-v4:1.0.0"
+    ],
+    "permissions": ["android.permission.CAMERA"],
+    "copy": [
+      {
+        "source": "android/src/general/java/org/*",
+        "dest": "lib/src/main/java/org"
+      },
+      {
+        "source": "android/src/main/res/*",
+        "dest": "lib/src/main/res/camera"
+      }
+    ],
+    "replaceInFile": [
+      {
+        "path": "lib/src/main/java/com/google/android/cameraview/SurfaceViewPreview.java",
+        "string": "org.reactnative.camera.R",
+        "replaceWith": "com.walmartlabs.ern.container.R"
+      },
+      {
+        "path": "lib/src/main/java/com/google/android/cameraview/TextureViewPreview.java",
+        "string": "org.reactnative.camera.R",
+        "replaceWith": "com.walmartlabs.ern.container.R"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add support for latest version of [`react-native-camera`](https://github.com/react-native-community/react-native-camera) native module for Android. 

iOS support is unclear at the moment, it might just be copying over the existing iOS configuration we already have for an older version of the plugin, or could be more complicated. Will be addressed through a separate PR.

This plugin configuration is dependent on [electrode-native#1603](https://github.com/electrode-io/electrode-native/pull/1603) which introduces proper support of resources injection. It will therefore only work with ern dev version (1000.0.0). We are planning to release this PR in ern 0.41.1.

Closes https://github.com/electrode-io/electrode-native-manifest/issues/166
Closes https://github.com/electrode-io/electrode-native-manifest/issues/168

**EDIT** [Sample demo miniapp here](https://github.com/belemaire/camera-miniapp)