### PR TITLE
Remove Flipper from react-native 0.62.0+ Podfile

### DIFF
--- a/plugins/ern_v0.41.0+/react-native_v0.62.0+/Podfile
+++ b/plugins/ern_v0.41.0+/react-native_v0.62.0+/Podfile
@@ -1,26 +1,6 @@
 platform :ios, '9.0'
 require_relative '{{{nodeModulesRelativePath}}}/@react-native-community/cli-platform-ios/native_modules'
 
-def add_flipper_pods!
-  version = '~> 0.33.1'
-  pod 'FlipperKit', version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitLayoutPlugin', version, :configuration => 'Debug'
-  pod 'FlipperKit/SKIOSNetworkPlugin', version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitReactPlugin', version, :configuration => 'Debug'
-end
-
-# Post Install processing for Flipper
-def flipper_post_install(installer)
-  installer.pods_project.targets.each do |target|
-    if target.name == 'YogaKit'
-      target.build_configurations.each do |config|
-        config.build_settings['SWIFT_VERSION'] = '4.1'
-      end
-    end
-  end
-end
-
 target '{{{projectName}}}' do
   # Pods for {{{projectName}}}
   pod 'FBLazyVector', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/FBLazyVector"
@@ -58,12 +38,4 @@ target '{{{projectName}}}' do
 
   use_native_modules!
 
-  # Enables Flipper.
-  #
-  # Note that if you have use_frameworks! enabled, Flipper will not work and
-  # you should disable these next few lines.
-  add_flipper_pods!
-  post_install do |installer|
-    flipper_post_install(installer)
-  end
 end


### PR DESCRIPTION
Already removed in React Native v0.63.0+ configuration (https://github.com/electrode-io/electrode-native-manifest/pull/178)

We don't want to inject Flipper in the Container. 
Flipper should be added to / configured from the native application project itself (if desired).