### PR TITLE
Add @react-native-community/art plugin support

### DIFF
--- a/plugins/ern_v0.14.0+/@react-native-community/art_v1.2.0+/ArtPlugin.java
+++ b/plugins/ern_v0.14.0+/@react-native-community/art_v1.2.0+/ArtPlugin.java
@@ -1,0 +1,15 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.reactnativecommunity.art.ARTPackage;
+
+public class ArtPlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new ARTPackage();
+    }
+}

--- a/plugins/ern_v0.14.0+/@react-native-community/art_v1.2.0+/config.json
+++ b/plugins/ern_v0.14.0+/@react-native-community/art_v1.2.0+/config.json
@@ -1,0 +1,30 @@
+{
+    "android": {
+      "root": "android"
+    },
+    "ios": {
+      "copy": [
+        {
+          "dest": "{{{projectName}}}/Libraries/ART",
+          "source": "ios/**"
+        }
+      ],
+      "pbxproj": {
+        "addHeaderSearchPath": [
+          "\"$(SRCROOT)/{{{projectName}}}/Libraries/ART/**\""
+        ],
+        "addProject": [
+          {
+            "group": "Libraries",
+            "path": "ART/ART.xcodeproj",
+            "staticLibs": [
+              {
+                "name": "libART.a",
+                "target": "ART"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
As for many other native modules, ART has been removed from React Native core (part of lean core effort) and moved to a separate third party maintained package [@react-native-community/art](https://github.com/react-native-community/art)