### PR TITLE
Add react-native-image-picker 1.0.0+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1500,7 +1500,7 @@
       "react-native-fbsdk@1.1.2",
       "react-native-fs@2.16.6",
       "react-native-gesture-handler@1.6.1",
-      "react-native-image-picker@2.3.1",
+      "react-native-image-picker@2.3.4",
       "react-native-keep-awake@4.0.0",
       "react-native-linear-gradient@2.5.6",
       "react-native-llimageview@2.0.4",

--- a/plugins/ern_v0.41.1+/react-native-image-picker_v1.0.0+/ImagePickerPlugin.java
+++ b/plugins/ern_v0.41.1+/react-native-image-picker_v1.0.0+/ImagePickerPlugin.java
@@ -1,0 +1,14 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactPackage;
+import com.imagepicker.ImagePickerPackage;
+
+public class ImagePickerPlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new ImagePickerPackage();
+    }
+}

--- a/plugins/ern_v0.41.1+/react-native-image-picker_v1.0.0+/config.json
+++ b/plugins/ern_v0.41.1+/react-native-image-picker_v1.0.0+/config.json
@@ -1,0 +1,58 @@
+{
+  "android": {
+    "root": "android",
+    "dependencies": [],
+    "permissions": [
+      "android.permission.CAMERA",
+      "android.permission.WRITE_EXTERNAL_STORAGE"
+    ],
+    "copy": [
+      {
+        "source": "android/src/main/res/*",
+        "dest": "lib/src/main/res/imagepicker"
+      }
+    ],
+    "replaceInFile": [
+      {
+        "path": "lib/src/main/java/com/imagepicker/utils/UI.java",
+        "string": "com.imagepicker.R",
+        "replaceWith": "com.walmartlabs.ern.container.R"
+      },
+      {
+        "path": "lib/src/main/java/com/imagepicker/ImagePickerModule.java",
+        "string": "R.style",
+        "replaceWith": "com.walmartlabs.ern.container.R.style"
+      },
+      {
+        "path": "lib/src/main/AndroidManifest.xml",
+        "string": "<application>",
+        "replaceWith": "<application>\n        <provider\n            android:name=\"com.imagepicker.FileProvider\"\n            android:authorities=\"${applicationId}.provider\"\n            android:exported=\"false\"\n            android:grantUriPermissions=\"true\">\n            <meta-data\n                android:name=\"android.support.FILE_PROVIDER_PATHS\"\n                android:resource=\"@xml/provider_paths\" />\n        </provider>"
+      }
+    ]
+  },
+  "ios": {
+    "copy": [
+      {
+        "dest": "{{{projectName}}}/Libraries/RNImagePicker",
+        "source": "ios/*"
+      }
+    ],
+    "pbxproj": {
+      "addHeaderSearchPath": [
+        "\"$(SRCROOT)/{{{projectName}}}/Libraries/RNImagePicker/**\""
+      ],
+      "addProject": [
+        {
+          "group": "Libraries",
+          "path": "RNImagePicker/RNImagePicker.xcodeproj",
+          "staticLibs": [
+            {
+              "name": "libRNImagePicker.a",
+              "target": "RNImagePicker"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add support for `react-native-image-picker` (a later version). I'm pretty sure this has been broken for a while, though the manifest already had an entry for 2.3.1. Since the library includes resources on the Android side, additional processing is required (similar to the recently added firebase libs).

A sample app that works with this branch: https://github.com/fbtmp/rnimgpkr-miniapp