### PR TITLE
Add support for ern 0.45

### DIFF
--- a/plugins/ern_v0.45.0+/README.md
+++ b/plugins/ern_v0.45.0+/README.md
@@ -1,0 +1,3 @@
+## Electrode Native v0.45 changes
+
+**Add support for configurable iOS deployment target:** [#1737](https://github.com/electrode-io/electrode-native/pull/1737)

--- a/plugins/ern_v0.45.0+/react-native_v0.61.0+/Podfile
+++ b/plugins/ern_v0.45.0+/react-native_v0.61.0+/Podfile
@@ -1,0 +1,43 @@
+platform :ios, '{{{iosDeploymentTarget}}}'
+require_relative '{{{nodeModulesRelativePath}}}/@react-native-community/cli-platform-ios/native_modules'
+
+target '{{{projectName}}}' do
+  # Pods for {{{projectName}}}
+  pod 'FBLazyVector', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/FBLazyVector"
+  pod 'FBReactNativeSpec', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/FBReactNativeSpec"
+  pod 'RCTRequired', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/RCTRequired"
+  pod 'RCTTypeSafety', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/TypeSafety"
+  pod 'React', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+  pod 'React-Core', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+  pod 'React-CoreModules', :path => '{{{nodeModulesRelativePath}}}/react-native/React/CoreModules'
+  pod 'React-Core/DevSupport', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+  pod 'React-RCTActionSheet', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/ActionSheetIOS'
+  pod 'React-RCTAnimation', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/NativeAnimation'
+  pod 'React-RCTBlob', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Blob'
+  pod 'React-RCTImage', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Image'
+  pod 'React-RCTLinking', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/LinkingIOS'
+  pod 'React-RCTNetwork', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Network'
+  pod 'React-RCTSettings', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Settings'
+  pod 'React-RCTText', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Text'
+  pod 'React-RCTVibration', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Vibration'
+  pod 'React-Core/RCTWebSocket', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+
+  pod 'React-cxxreact', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/cxxreact'
+  pod 'React-jsi', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/jsi'
+  pod 'React-jsiexecutor', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/jsiexecutor'
+  pod 'React-jsinspector', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/jsinspector'
+  pod 'ReactCommon/jscallinvoker', :path => "{{{nodeModulesRelativePath}}}/react-native/ReactCommon"
+  pod 'ReactCommon/turbomodule/core', :path => "{{{nodeModulesRelativePath}}}/react-native/ReactCommon"
+  pod 'Yoga', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/yoga'
+
+  pod 'DoubleConversion', :podspec => '{{{nodeModulesRelativePath}}}/react-native/third-party-podspecs/DoubleConversion.podspec'
+  pod 'glog', :podspec => '{{{nodeModulesRelativePath}}}/react-native/third-party-podspecs/glog.podspec'
+  pod 'Folly', :podspec => '{{{nodeModulesRelativePath}}}/react-native/third-party-podspecs/Folly.podspec'
+
+{{#extraPods}}
+  {{{.}}}
+{{/extraPods}}
+
+  use_native_modules!
+
+end

--- a/plugins/ern_v0.45.0+/react-native_v0.61.0+/config.json
+++ b/plugins/ern_v0.45.0+/react-native_v0.61.0+/config.json
@@ -1,0 +1,5 @@
+{
+  "ios": {
+    "podfile": "Podfile"
+  }
+}

--- a/plugins/ern_v0.45.0+/react-native_v0.62.0+/Podfile
+++ b/plugins/ern_v0.45.0+/react-native_v0.62.0+/Podfile
@@ -1,0 +1,43 @@
+platform :ios, '{{{iosDeploymentTarget}}}'
+require_relative '{{{nodeModulesRelativePath}}}/@react-native-community/cli-platform-ios/native_modules'
+
+target '{{{projectName}}}' do
+  # Pods for {{{projectName}}}
+  pod 'FBLazyVector', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/FBLazyVector"
+  pod 'FBReactNativeSpec', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/FBReactNativeSpec"
+  pod 'RCTRequired', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/RCTRequired"
+  pod 'RCTTypeSafety', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/TypeSafety"
+  pod 'React', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+  pod 'React-Core', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+  pod 'React-CoreModules', :path => '{{{nodeModulesRelativePath}}}/react-native/React/CoreModules'
+  pod 'React-Core/DevSupport', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+  pod 'React-RCTActionSheet', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/ActionSheetIOS'
+  pod 'React-RCTAnimation', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/NativeAnimation'
+  pod 'React-RCTBlob', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Blob'
+  pod 'React-RCTImage', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Image'
+  pod 'React-RCTLinking', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/LinkingIOS'
+  pod 'React-RCTNetwork', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Network'
+  pod 'React-RCTSettings', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Settings'
+  pod 'React-RCTText', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Text'
+  pod 'React-RCTVibration', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Vibration'
+  pod 'React-Core/RCTWebSocket', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+
+  pod 'React-cxxreact', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/cxxreact'
+  pod 'React-jsi', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/jsi'
+  pod 'React-jsiexecutor', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/jsiexecutor'
+  pod 'React-jsinspector', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/jsinspector'
+  pod 'ReactCommon/callinvoker', :path => "{{{nodeModulesRelativePath}}}/react-native/ReactCommon"
+  pod 'ReactCommon/turbomodule/core', :path => "{{{nodeModulesRelativePath}}}/react-native/ReactCommon"
+  pod 'Yoga', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/yoga', :modular_headers => true
+
+  pod 'DoubleConversion', :podspec => '{{{nodeModulesRelativePath}}}/react-native/third-party-podspecs/DoubleConversion.podspec'
+  pod 'glog', :podspec => '{{{nodeModulesRelativePath}}}/react-native/third-party-podspecs/glog.podspec'
+  pod 'Folly', :podspec => '{{{nodeModulesRelativePath}}}/react-native/third-party-podspecs/Folly.podspec'
+
+{{#extraPods}}
+  {{{.}}}
+{{/extraPods}}
+
+  use_native_modules!
+
+end

--- a/plugins/ern_v0.45.0+/react-native_v0.62.0+/config.json
+++ b/plugins/ern_v0.45.0+/react-native_v0.62.0+/config.json
@@ -1,0 +1,5 @@
+{
+  "ios": {
+    "podfile": "Podfile"
+  }
+}

--- a/plugins/ern_v0.45.0+/react-native_v0.63.0+/Podfile
+++ b/plugins/ern_v0.45.0+/react-native_v0.63.0+/Podfile
@@ -1,0 +1,42 @@
+platform :ios, '{{{iosDeploymentTarget}}}'
+require_relative '{{{nodeModulesRelativePath}}}/@react-native-community/cli-platform-ios/native_modules'
+
+target '{{{projectName}}}' do
+  # Pods for {{{projectName}}}
+  pod 'FBLazyVector', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/FBLazyVector"
+  pod 'FBReactNativeSpec', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/FBReactNativeSpec"
+  pod 'RCTRequired', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/RCTRequired"
+  pod 'RCTTypeSafety', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/TypeSafety"
+  pod 'React', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+  pod 'React-Core', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+  pod 'React-CoreModules', :path => '{{{nodeModulesRelativePath}}}/react-native/React/CoreModules'
+  pod 'React-Core/DevSupport', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+  pod 'React-RCTActionSheet', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/ActionSheetIOS'
+  pod 'React-RCTAnimation', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/NativeAnimation'
+  pod 'React-RCTBlob', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Blob'
+  pod 'React-RCTImage', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Image'
+  pod 'React-RCTLinking', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/LinkingIOS'
+  pod 'React-RCTNetwork', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Network'
+  pod 'React-RCTSettings', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Settings'
+  pod 'React-RCTText', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Text'
+  pod 'React-RCTVibration', :path => '{{{nodeModulesRelativePath}}}/react-native/Libraries/Vibration'
+  pod 'React-Core/RCTWebSocket', :path => '{{{nodeModulesRelativePath}}}/react-native/'
+
+  pod 'React-cxxreact', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/cxxreact'
+  pod 'React-jsi', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/jsi'
+  pod 'React-jsiexecutor', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/jsiexecutor'
+  pod 'React-jsinspector', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/jsinspector'
+  pod 'React-callinvoker', :path => "{{{nodeModulesRelativePath}}}/react-native/ReactCommon/callinvoker"
+  pod 'ReactCommon/turbomodule/core', :path => "{{{nodeModulesRelativePath}}}/react-native/ReactCommon"
+  pod 'Yoga', :path => '{{{nodeModulesRelativePath}}}/react-native/ReactCommon/yoga', :modular_headers => true
+
+  pod 'DoubleConversion', :podspec => '{{{nodeModulesRelativePath}}}/react-native/third-party-podspecs/DoubleConversion.podspec'
+  pod 'glog', :podspec => '{{{nodeModulesRelativePath}}}/react-native/third-party-podspecs/glog.podspec'
+  pod 'Folly', :podspec => '{{{nodeModulesRelativePath}}}/react-native/third-party-podspecs/Folly.podspec'
+
+{{#extraPods}}
+  {{{.}}}
+{{/extraPods}}
+
+  use_native_modules!
+end

--- a/plugins/ern_v0.45.0+/react-native_v0.63.0+/config.json
+++ b/plugins/ern_v0.45.0+/react-native_v0.63.0+/config.json
@@ -1,0 +1,5 @@
+{
+  "ios": {
+    "podfile": "Podfile"
+  }
+}


### PR DESCRIPTION
`plugins/ern_v0.45.0+` is a copy of `plugins/ern_v0.41.0+` with **two** differences:

- The first line in the three Podspec files: Instead of hardcoding the deployment target, it is now a variable
- Process `extraPods` as array via mustache instead of converting it into a string with indentation in the core platform

Prerequisite for a potential future version to support new feature added via https://github.com/electrode-io/electrode-native/pull/1737