### PR TITLE
Add extraPodspecsSources support for iOS

### DIFF
--- a/plugins/ern_v0.45.0+/react-native_v0.61.0+/Podfile
+++ b/plugins/ern_v0.45.0+/react-native_v0.61.0+/Podfile
@@ -1,6 +1,10 @@
 platform :ios, '{{{iosDeploymentTarget}}}'
 require_relative '{{{nodeModulesRelativePath}}}/@react-native-community/cli-platform-ios/native_modules'
 
+{{#extraPodspecsSources}}
+{{{.}}}
+{{/extraPodspecsSources}}
+
 target '{{{projectName}}}' do
   # Pods for {{{projectName}}}
   pod 'FBLazyVector', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/FBLazyVector"

--- a/plugins/ern_v0.45.0+/react-native_v0.62.0+/Podfile
+++ b/plugins/ern_v0.45.0+/react-native_v0.62.0+/Podfile
@@ -1,6 +1,10 @@
 platform :ios, '{{{iosDeploymentTarget}}}'
 require_relative '{{{nodeModulesRelativePath}}}/@react-native-community/cli-platform-ios/native_modules'
 
+{{#extraPodspecsSources}}
+{{{.}}}
+{{/extraPodspecsSources}}
+
 target '{{{projectName}}}' do
   # Pods for {{{projectName}}}
   pod 'FBLazyVector', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/FBLazyVector"

--- a/plugins/ern_v0.45.0+/react-native_v0.63.0+/Podfile
+++ b/plugins/ern_v0.45.0+/react-native_v0.63.0+/Podfile
@@ -1,6 +1,10 @@
 platform :ios, '{{{iosDeploymentTarget}}}'
 require_relative '{{{nodeModulesRelativePath}}}/@react-native-community/cli-platform-ios/native_modules'
 
+{{#extraPodspecsSources}}
+{{{.}}}
+{{/extraPodspecsSources}}
+
 target '{{{projectName}}}' do
   # Pods for {{{projectName}}}
   pod 'FBLazyVector', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/FBLazyVector"


### PR DESCRIPTION
Update React Native *(>=0.61)* manifest configs to add `extraPodspecsSources` directive support, to be introduced in Electrode Native 0.45.6.

This PR can be merged immediately, with no side effects, but better to wait on ERN 0.45.6 to be released prior to merging, to avoid any confusion having not supported mustache model placeholders in the config on master. 

Associated Electrode Native PR : https://github.com/electrode-io/electrode-native/pull/1761