### PR TITLE
Add react-native-permissions 2.0.0+

### DIFF
--- a/plugins/ern_v0.14.0+/react-native-permissions_v2.0.0+/RNPermissionsPackagePlugin.java
+++ b/plugins/ern_v0.14.0+/react-native-permissions_v2.0.0+/RNPermissionsPackagePlugin.java
@@ -1,0 +1,14 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactPackage;
+import com.reactnativecommunity.rnpermissions.RNPermissionsPackage;
+
+public class RNPermissionsPackagePlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new RNPermissionsPackage();
+    }
+}

--- a/plugins/ern_v0.14.0+/react-native-permissions_v2.0.0+/config.json
+++ b/plugins/ern_v0.14.0+/react-native-permissions_v2.0.0+/config.json
@@ -1,0 +1,31 @@
+{
+  "android": {
+    "root": "android",
+    "dependencies": []
+  },
+  "ios": {
+    "copy": [
+      {
+        "dest": "{{{projectName}}}/Libraries/RNPermissions",
+        "source": "ios/*"
+      }
+    ],
+    "pbxproj": {
+      "addHeaderSearchPath": [
+        "\"$(SRCROOT)/{{{projectName}}}/Libraries/RNPermissions/**\""
+      ],
+      "addProject": [
+        {
+          "group": "Libraries",
+          "path": "RNPermissions/RNPermissions.xcodeproj",
+          "staticLibs": [
+            {
+              "name": "libRNPermissions.a",
+              "target": "RNPermissions"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
We already have a manifest entry for version `2.0.10` of `react-native-permissions`, but the existing plugin config was for 1.0.0+ and was missing the android config.