### PR TITLE
Fix react-native-gesture-handler android plugin configuration

### DIFF
--- a/plugins/ern_v0.14.0+/react-native-gesture-handler_v1.4.1+/config.json
+++ b/plugins/ern_v0.14.0+/react-native-gesture-handler_v1.4.1+/config.json
@@ -1,6 +1,12 @@
 {
   "android": {
     "root": "android",
+    "copy": [
+      {
+        "source": "android/lib/src/main/java/com/swmansion/gesturehandler/*",
+        "dest": "lib/src/main/java/com/swmansion/gesturehandler"
+      }
+    ],
     "dependencies": []
   },
   "ios": {


### PR DESCRIPTION
Fix [react-native-gesture-handler](https://github.com/software-mansion/react-native-gesture-handler) plugin configuration for Android.

The plugin contains an additional source set in [lib directory](https://github.com/software-mansion/react-native-gesture-handler/tree/master/android) that needs to be manually copied to the container _(by default only the main standard source set from src/main is copied to the container)_