### PR TITLE
manifest config for appcenter 3.0.1

### DIFF
--- a/plugins/ern_v0.14.0+/appcenter-analytics_v3.0.1+/AppCenterReactNativeAnalyticsPlugin.java
+++ b/plugins/ern_v0.14.0+/appcenter-analytics_v3.0.1+/AppCenterReactNativeAnalyticsPlugin.java
@@ -1,0 +1,38 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.microsoft.appcenter.reactnative.analytics.AppCenterReactNativeAnalyticsPackage;
+
+public class AppCenterReactNativeAnalyticsPlugin implements ReactPlugin<AppCenterReactNativeAnalyticsPlugin.Config> {
+    public ReactPackage hook(@NonNull Application application,
+                             @Nullable Config config) {
+        if (config != null && config.enableInJs != null) {
+            return new AppCenterReactNativeAnalyticsPackage(application, config.enableInJs);
+        }
+        boolean enableDebugMode = false;
+        if (config != null && config.enableDebugMode) {
+            enableDebugMode = true;
+        }
+        return new AppCenterReactNativeAnalyticsPackage(application, enableDebugMode);
+    }
+
+    public static class Config implements ReactPluginConfig {
+        private boolean enableDebugMode;
+        private String enableInJs;
+
+        public Config enableDebugMode(boolean enableDebugMode) {
+            this.enableDebugMode = enableDebugMode;
+            return this;
+        }
+
+        public Config enableInJs(String enableInJs) {
+            this.enableInJs = enableInJs;
+            return this;
+        }
+    }
+}

--- a/plugins/ern_v0.14.0+/appcenter-analytics_v3.0.1+/config.json
+++ b/plugins/ern_v0.14.0+/appcenter-analytics_v3.0.1+/config.json
@@ -1,0 +1,10 @@
+{
+  "android": {
+    "root": "",
+    "moduleName": "android",
+    "dependencies": [
+      "com.microsoft.appcenter:appcenter-analytics:3.1.0",
+      "com.microsoft.appcenter.reactnative:appcenter-react-native:3.0.1"
+    ]
+  }
+}

--- a/plugins/ern_v0.14.0+/appcenter-crashes_v3.0.1+/AppCenterReactNativeCrashesPlugin.java
+++ b/plugins/ern_v0.14.0+/appcenter-crashes_v3.0.1+/AppCenterReactNativeCrashesPlugin.java
@@ -1,0 +1,25 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.microsoft.appcenter.reactnative.crashes.AppCenterReactNativeCrashesPackage;
+
+public class AppCenterReactNativeCrashesPlugin implements ReactPlugin<AppCenterReactNativeCrashesPlugin.Config> {
+    public ReactPackage hook(@NonNull Application application,
+                             @Nullable Config config) {
+        return new AppCenterReactNativeCrashesPackage(application, config != null ? config.automaticCrashDispatchByJs : null);
+    }
+
+    public static class Config implements ReactPluginConfig {
+        private String automaticCrashDispatchByJs;
+
+        public Config automaticCrashDispatchByJs(String automaticCrashDispatchByJs) {
+            this.automaticCrashDispatchByJs = automaticCrashDispatchByJs;
+            return this;
+        }
+    }
+}

--- a/plugins/ern_v0.14.0+/appcenter-crashes_v3.0.1+/config.json
+++ b/plugins/ern_v0.14.0+/appcenter-crashes_v3.0.1+/config.json
@@ -1,0 +1,10 @@
+{
+  "android": {
+    "root": "",
+    "moduleName": "android",
+    "dependencies": [
+      "com.microsoft.appcenter:appcenter-crashes:3.1.0",
+      "com.microsoft.appcenter.reactnative:appcenter-react-native:3.0.1"
+    ]
+  }
+}

--- a/plugins/ern_v0.14.0+/appcenter_v3.0.1+/AppCenterReactNativePlugin.java
+++ b/plugins/ern_v0.14.0+/appcenter_v3.0.1+/AppCenterReactNativePlugin.java
@@ -1,0 +1,16 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.microsoft.appcenter.reactnative.appcenter.AppCenterReactNativePackage;
+
+public class AppCenterReactNativePlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application,
+                      @Nullable ReactPluginConfig config) {
+        return new AppCenterReactNativePackage(application);
+    }
+}

--- a/plugins/ern_v0.14.0+/appcenter_v3.0.1+/config.json
+++ b/plugins/ern_v0.14.0+/appcenter_v3.0.1+/config.json
@@ -1,0 +1,10 @@
+{
+  "android": {
+    "root": "",
+    "moduleName": "android",
+    "dependencies": [
+      "com.microsoft.appcenter:appcenter:3.1.0",
+      "com.microsoft.appcenter.reactnative:appcenter-react-native:3.0.1"
+    ]
+  }
+}


### PR DESCRIPTION
Error 

```
[=== Starting build and publication ===]
/private/var/folders/8h/wyvvtdws1v3fcr7qfbyvg8_r0000gn/T/tmp-687670pK3TEnlcJ5o /Users/r0p00uj/GitHub/OYI-Android/app
/Users/r0p00uj/GitHub/OYI-Android/app
✖ An error occurred: Command failed: ./gradlew lib:uploadArchives
✖ /private/var/folders/8h/wyvvtdws1v3fcr7qfbyvg8_r0000gn/T/tmp-687670pK3TEnlcJ5o/lib/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesModule.java:106: error: cannot find symbol
✖         Crashes.hasReceivedMemoryWarningInLastSession().thenAccept(new AppCenterConsumer<Boolean>() {
✖                ^
✖   symbol:   method hasReceivedMemoryWarningInLastSession()
✖   location: class Crashes
✖ /private/var/folders/8h/wyvvtdws1v3fcr7qfbyvg8_r0000gn/T/tmp-687670pK3TEnlcJ5o/lib/src/main/java/com/microsoft/appcenter/reactnative/crashes/AppCenterReactNativeCrashesUtils.java:44: error: cannot find symbol
✖         String stackTrace = errorReport.getStackTrace();
✖                                        ^
✖   symbol:   method getStackTrace()
```
Align the bindings to the right transitive dependencies https://github.com/microsoft/appcenter-sdk-react-native/tree/3.0.1