### PR TITLE
Fix React Native 0.64.x Podfile

### DIFF
--- a/plugins/ern_v0.45.0+/react-native_v0.64.0+/Podfile
+++ b/plugins/ern_v0.45.0+/react-native_v0.64.0+/Podfile
@@ -9,6 +9,24 @@ require_relative '{{{nodeModulesRelativePath}}}/@react-native-community/cli-plat
 {{{.}}}
 {{/extraPodfileStatements}}
 
+post_install do |installer|
+  react_native_post_install(installer)
+
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
+    end
+
+    if (target.name&.eql?('FBReactNativeSpec'))
+      target.build_phases.each do |build_phase|
+        if (build_phase.respond_to?(:name) && build_phase.name.eql?('[CP-User] Generate Specs'))
+          target.build_phases.move(build_phase, 0)
+        end
+      end
+    end
+  end
+end
+
 target '{{{projectName}}}' do
   # Pods for {{{projectName}}}
   pod 'FBLazyVector', :path => "{{{nodeModulesRelativePath}}}/react-native/Libraries/FBLazyVector"


### PR DESCRIPTION
Fix an iOS issue with `FBReactNativeSpec` project, causing in some cases _(when using some specific native modules)_ a cycle issue during container build time _(see screenshot below)_

![Screen Shot 2021-05-10 at 1 52 54 PM](https://user-images.githubusercontent.com/1390588/117735956-6b245800-b1ab-11eb-967b-7e218ec8aeff.png)

This has been experienced by some users and seems like it isn't fixed in RN yet. The problem has been reported in https://github.com/facebook/react-native/issues/31034

It seems like the order of script execution in build phases of `FBReactNativeSpec` is causing the problem. The `Generate Spec` script should be run BEFORE the `Headers` one, as seen on screenshot below

<img width="243" alt="Screen Shot 2021-05-10 at 4 17 19 PM" src="https://user-images.githubusercontent.com/1390588/117735865-3b755000-b1ab-11eb-9344-ac584a72ca54.png">

Unfortunately, in RN code base, the order is reversed.

A fix has been suggested in https://github.com/facebook/react-native/issues/31034#issuecomment-812564390

This PR is just applying this fix to RN 0.64 Podfile stored in the manifest, so that the proper order is established during pod install _(reorder done post pod install)_.

I was able to reproduce this issue with an internal project, and was able to validate that this fix is working _(manually at first, then via manifest with this updated Podfile)_.

