### PR TITLE
Add support for react-native-pager-view plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ in which to store the configuration might look puzzling at first.
 To know which directory to use for a new plugin configuration, just go through
 the following bullet points from top to bottom.
 
+- Does your plugin contains an Android implementation written in Kotlin ?\
+Use `ern_v0.48.0+`
+
 - Does your plugin configuration need to add Android resources (from a `res` directory) to the container or to add iOS resources to the container ?\
 Use `ern_v0.41.1+`
 
@@ -61,6 +64,10 @@ This directive allows to add an embedded Framework to the container project.
 
 **Adds support for React Native >= 0.61.0:** [#1542][7]\
 
+### Electrode Native v0.48 changes
+
+**Adds support for Kotlin implementeed plugins** [#1111][8]\
+
 [1]: https://native.electrode.io/reference/index-3
 [2]: https://developer.android.com/guide/topics/permissions/overview
 [3]: https://github.com/electrode-io/electrode-native/pull/606
@@ -68,3 +75,4 @@ This directive allows to add an embedded Framework to the container project.
 [5]: https://github.com/electrode-io/electrode-native/pull/1197
 [6]: https://github.com/electrode-io/electrode-native/pull/1478
 [7]: https://github.com/electrode-io/electrode-native/pull/1542
+[8]: https://github.com/electrode-io/electrode-native/pull/1111

--- a/manifest.json
+++ b/manifest.json
@@ -1722,6 +1722,7 @@
       "react-native-msal@3.0.4",
       "react-native-network-info@5.2.1",
       "react-native-orientation@3.1.3",
+      "react-native-pager-view@5.1.7",
       "react-native-pdf@6.1.1",
       "react-native-permissions@2.0.10",
       "react-native-photo-view@1.5.2",

--- a/plugins/ern_v0.48.0+/react-native-pager-view_v5.0.0+/PagerViewPlugin.java
+++ b/plugins/ern_v0.48.0+/react-native-pager-view_v5.0.0+/PagerViewPlugin.java
@@ -1,0 +1,16 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.reactnativepagerview.PagerViewPackage;
+
+public class PagerViewPlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application,
+                      @Nullable ReactPluginConfig config) {
+        return new PagerViewPackage();
+    }
+}

--- a/plugins/ern_v0.48.0+/react-native-pager-view_v5.0.0+/config.json
+++ b/plugins/ern_v0.48.0+/react-native-pager-view_v5.0.0+/config.json
@@ -1,0 +1,10 @@
+{
+  "android": {
+    "root": "",
+    "moduleName": "android",
+    "dependencies": [
+      "androidx.viewpager2:viewpager2:1.0.0"
+    ]
+  },
+  "ios": {}
+}


### PR DESCRIPTION
This native module is implemented with Kotlin on Android.

This is the first such plugin to be added to our manifest. 
It needs Kotlin support in the container, which has been added in https://github.com/electrode-io/electrode-native/pull/1807 and will be released in Electrode Native 0.48.0.

Because of this, the plugin configuration is part of a new version directory `ern_v0.48.0+`.
Also updated instructions in README.

This PR is not to be merged before 0.48.0 release _(will not break anything, but makes no sense to merge it before)_
