### PR TITLE
Add plugin for react-native-electrode-bridge 1.6.0

### DIFF
--- a/plugins/ern_v0.13.0+/react-native-electrode-bridge_v1.6.0+/ElectrodeBridgePlugin.java
+++ b/plugins/ern_v0.13.0+/react-native-electrode-bridge_v1.6.0+/ElectrodeBridgePlugin.java
@@ -1,0 +1,17 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.ReactPackage;
+import com.walmartlabs.electrode.reactnative.bridge.ElectrodeBridgePackage;
+
+public class ElectrodeBridgePlugin implements ReactPlugin {
+    @Override
+    public ReactPackage hook(@NonNull Application application,
+                      @Nullable ReactPluginConfig config) {
+        return new ElectrodeBridgePackage();
+    }
+}

--- a/plugins/ern_v0.13.0+/react-native-electrode-bridge_v1.6.0+/config.json
+++ b/plugins/ern_v0.13.0+/react-native-electrode-bridge_v1.6.0+/config.json
@@ -1,0 +1,67 @@
+{
+  "android": {},
+  "ios": {
+    "requiresManualLinking": true,
+    "copy": [
+      { "source": "ios/ElectrodeReactNativeBridge/*", "dest": "{{{projectName}}}/ElectrodeReactNativeBridge" }
+    ],
+    "containerPublicHeader":["ElectrodeBridgeHolder.h",
+                             "ElectrodeBridgeProtocols.h",
+                             "ElectrodeBridgeEvent.h",
+                             "ElectrodeBridgeRequest.h",
+                             "ElectrodeLogger.h"
+    ],
+    "replaceInFile": [
+      {
+        "path": "{{{projectName}}}/ElectrodeReactNativeBridge/ElectrodeBridgeMessage.m",
+        "string": "#import <ElectrodeReactNativeBridge/ElectrodeReactNativeBridge-Swift.h>",
+        "replaceWith": "#import <{{{projectName}}}/{{{projectName}}}-Swift.h>"
+      }
+    ],
+    "pbxproj": {
+      "addHeader": [
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeEvent.h", "group": "ElectrodeReactNativeBridge", "public": true },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeFailureMessage.h", "group": "ElectrodeReactNativeBridge", "public": true },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeHolder.h", "group": "ElectrodeReactNativeBridge", "public": true },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeMessage.h", "group": "ElectrodeReactNativeBridge", "public": true },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeProtocols.h", "group": "ElectrodeReactNativeBridge", "public": true },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeRequest.h", "group": "ElectrodeReactNativeBridge", "public": true },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeTransaction.h", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.h", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver_Internal.h", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeEventDispatcher.h", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeEventRegistrar.h", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeRequestDispatcher.h", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeRequestRegistrar.h", "group": "ElectrodeReactNativeBridge"},
+        { "path": "ElectrodeReactNativeBridge/ElectrodeReactNativeBridge.h", "group": "ElectrodeReactNativeBridge"},
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeResponse.h", "group": "ElectrodeReactNativeBridge"},
+        { "path": "ElectrodeReactNativeBridge/ElectrodeLogger.h", "group": "ElectrodeReactNativeBridge", "public": true}
+      ],
+      "addSource": [
+        { "path": "ElectrodeReactNativeBridge/ElectrodeObject.swift", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/Bridgeable.swift", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeRequestHandlerProcessor.swift", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeRequestProcessor.swift", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeUtilities.swift", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/EventListenerProcessor.swift", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/EventProcessor.swift", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/Processor.swift", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/None.swift", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeEvent.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeFailureMessage.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeHolder.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeMessage.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeProtocols.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeRequest.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeResponse.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeTransaction.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeBridgeTransceiver.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeEventDispatcher.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeEventRegistrar.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeRequestDispatcher.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeRequestRegistrar.m", "group": "ElectrodeReactNativeBridge" },
+        { "path": "ElectrodeReactNativeBridge/ElectrodeLogger.m", "group": "ElectrodeReactNativeBridge"}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add new plugin configuration for `react-native-electrode-bridge@^1.6.0` - In preparation for new bridge and ERN release.

- android configuration no longer needs `moduleName` value (as the layout was standardized in https://github.com/electrode-io/react-native-electrode-bridge/pull/95)
- ios configuration was copied 1:1 from the previous config

Contains partial prerequisites from #235 

Originally, bridge was to be released as 2.0.0, but changed to 1.6.0, as the update does not contain API breaking changes.