### PR TITLE
Update RN to 0.68.7 in Dev Manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1935,7 +1935,7 @@
       "ern-navigation@^2.1.0",
       "lottie-ios@3.1.6",
       "lottie-react-native@3.3.2",
-      "react-native@0.67.5",
+      "react-native@0.68.7",
       "react-native-admob@1.3.2",
       "react-native-android-settings-library@1.0.6",
       "react-native-android-wifi@0.0.41",


### PR DESCRIPTION
React Native 0.68.7 is published to Maven Central - https://repo1.maven.org/maven2/com/walmartlabs/ern/react-native/
Update RN version 0.68.7 in dev manifest for local testing