### PR TITLE
Add RN-image-picker plugin 3.0.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1949,7 +1949,7 @@
       "react-native-fbsdk@1.1.2",
       "react-native-fs@2.16.6",
       "react-native-gesture-handler@1.6.1",
-      "react-native-image-picker@2.3.4",
+      "react-native-image-picker@3.0.0",
       "react-native-keep-awake@4.0.0",
       "react-native-keychain@6.0.0",
       "react-native-keyevent@0.2.8",

--- a/plugins/ern_v0.46.0+/react-native-image-picker_v3.0.0+/ImagePickerPackagePlugin.java
+++ b/plugins/ern_v0.46.0+/react-native-image-picker_v3.0.0+/ImagePickerPackagePlugin.java
@@ -1,0 +1,16 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.ReactPackage;
+import com.imagepicker.ImagePickerPackage;
+
+public class ImagePickerPackagePlugin implements ReactPlugin {
+    @Override
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new ImagePickerPackage();
+    }
+}

--- a/plugins/ern_v0.46.0+/react-native-image-picker_v3.0.0+/config.json
+++ b/plugins/ern_v0.46.0+/react-native-image-picker_v3.0.0+/config.json
@@ -1,0 +1,50 @@
+{
+  "android": {
+    "root": "android",
+    "dependencies": [
+      "implementation 'androidx.exifinterface:exifinterface:1.3.1'"
+    ],
+    "permissions": [
+      "android.permission.CAMERA",
+      "android.permission.WRITE_EXTERNAL_STORAGE"
+    ],
+    "copy": [
+      {
+        "source": "android/src/main/res/*",
+        "dest": "lib/src/main/res/imagepicker"
+      }
+    ],
+    "replaceInFile": [
+      {
+        "path": "lib/src/main/AndroidManifest.xml",
+        "string": "<application>",
+        "replaceWith": "<application>\n        <provider\n            android:name=\"com.imagepicker.ImagePickerProvider\"\n            android:authorities=\"${applicationId}.imagepickerprovider\"\n            android:exported=\"false\"\n            android:grantUriPermissions=\"true\">\n            <meta-data\n                android:name=\"android.support.FILE_PROVIDER_PATHS\"\n                android:resource=\"@xml/imagepicker_provider_paths\" />\n        </provider>"
+      }
+    ]
+  },
+  "ios": {
+    "copy": [
+      {
+        "dest": "{{{projectName}}}/Libraries/RNImagePicker",
+        "source": "ios/*"
+      }
+    ],
+    "pbxproj": {
+      "addHeaderSearchPath": [
+        "\"$(SRCROOT)/{{{projectName}}}/Libraries/RNImagePicker/**\""
+      ],
+      "addProject": [
+        {
+          "group": "Libraries",
+          "path": "RNImagePicker/RNImagePicker.xcodeproj",
+          "staticLibs": [
+            {
+              "name": "libRNImagePicker.a",
+              "target": "RNImagePicker"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
react-native-imagePicker is rewritten in 3.0.0.- https://github.com/react-native-image-picker/react-native-image-picker/releases/tag/3.0.0.  Adding plugin support for 3.0.0+.